### PR TITLE
Feature/GPP-296: Dropdowns for agencies and subjects

### DIFF
--- a/config/authorities/agencies.yml
+++ b/config/authorities/agencies.yml
@@ -7,6 +7,8 @@ terms:
     term: Administrative Trials and Hearings, Office of (OATH)
   - id: Aging, Department for the (DFTA)
     term: Aging, Department for the (DFTA)
+  - id: Borough Presidents
+    term: Borough Presidents
   - id: Buildings, Department of (DOB)
     term: Buildings, Department of (DOB)
   - id: Business Integrity Commission (BIC)
@@ -25,6 +27,8 @@ terms:
     term: City Planning, Department of (DCP)
   - id: Citywide Administrative Services, Department of (DCAS)
     term: Citywide Administrative Services, Department of (DCAS)
+  - id: Civic Engagement Commision (CEC)
+    term: Civic Engagement Commision (CEC)
   - id: Civil Service Commission (CSC)
     term: Civil Service Commission (CSC)
   - id: Civilian Complaint Review Board (CCRB)

--- a/config/authorities/publication_subjects.yml
+++ b/config/authorities/publication_subjects.yml
@@ -1,4 +1,6 @@
 terms:
+  - id: Accessibility
+    term: Accessibility
   - id: Accounting
     term: Accounting
   - id: Advertising
@@ -91,6 +93,8 @@ terms:
     term: Electric Power
   - id: Emergencies
     term: Emergencies
+  - id: Emergency Preparedness
+    term: Emergency Preparedness
   - id: Employment
     term: Employment
   - id: Energy
@@ -127,6 +131,8 @@ terms:
     term: Government
   - id: Government - Citizen participation
     term: Government - Citizen participation
+  - id: Hazard Mitigation
+    term: Hazard Mitigation
   - id: Hazardous Materials
     term: Hazardous Materials
   - id: Health
@@ -225,6 +231,8 @@ terms:
     term: Purchasing Methods
   - id: Public Authorities
     term: Public Authorities
+  - id: Public Health
+    term: Public Health
   - id: Public Welfare
     term: Public Welfare
   - id: Queens


### PR DESCRIPTION
Adds following agencies as options:
Note: Commission on Gender Equity (CGE) was already existing 
- Borough Presidents
- Civil Engagement Commission (CEC)

Adds following reports types as options:
- Emergency Preparedness
- Hazard Mitigation
- Accessibility
- Public Health 