### PR TITLE
Feature/GPP-273: Sort Changes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -21,6 +21,10 @@ class CatalogController < ApplicationController
     solr_name('agency', :stored_sortable)
   end
 
+  def self.date_published_field
+    solr_name('date_published', :stored_sortable)
+  end
+
   configure_blacklight do |config|
     config.view.gallery.partials = [:index_header, :index]
     config.view.masonry.partials = [:index]
@@ -267,15 +271,13 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "score desc, #{date_published_field} desc", label: "relevance"
     config.add_sort_field "#{title_field} asc", :label => "Title (A-Z)"
     config.add_sort_field "#{title_field} desc", :label => "Title (Z-A)"
     config.add_sort_field "#{agency_field} asc", :label => "Agency (A-Z)"
     config.add_sort_field "#{agency_field} desc", :label => "Agency (Z-A)"
+    config.add_sort_field "#{date_published_field} desc", :label => "Date Published (Newest)"
+    config.add_sort_field "#{date_published_field} asc", :label => "Date Published (Oldest)"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -13,6 +13,14 @@ class CatalogController < ApplicationController
     solr_name('system_modified', :stored_sortable, type: :date)
   end
 
+  def self.title_field
+    solr_name('title', :stored_sortable)
+  end
+
+  def self.agency_field
+    solr_name('agency', :stored_sortable)
+  end
+
   configure_blacklight do |config|
     config.view.gallery.partials = [:index_header, :index]
     config.view.masonry.partials = [:index]
@@ -264,6 +272,10 @@ class CatalogController < ApplicationController
     config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
     config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "#{title_field} asc", :label => "Title (A-Z)"
+    config.add_sort_field "#{title_field} desc", :label => "Title (Z-A)"
+    config.add_sort_field "#{agency_field} asc", :label => "Agency (A-Z)"
+    config.add_sort_field "#{agency_field} desc", :label => "Agency (Z-A)"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -272,12 +272,12 @@ class CatalogController < ApplicationController
     # except in the relevancy case).
     # label is key, solr field is value
     config.add_sort_field "score desc, #{date_published_field} desc", label: "relevance"
+    config.add_sort_field "#{date_published_field} desc", :label => "Date Published (Newest)"
+    config.add_sort_field "#{date_published_field} asc", :label => "Date Published (Oldest)"
     config.add_sort_field "#{title_field} asc", :label => "Title (A-Z)"
     config.add_sort_field "#{title_field} desc", :label => "Title (Z-A)"
     config.add_sort_field "#{agency_field} asc", :label => "Agency (A-Z)"
     config.add_sort_field "#{agency_field} desc", :label => "Agency (Z-A)"
-    config.add_sort_field "#{date_published_field} desc", :label => "Date Published (Newest)"
-    config.add_sort_field "#{date_published_field} asc", :label => "Date Published (Oldest)"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -271,7 +271,7 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field "score desc, #{date_published_field} desc", label: "relevance"
+    config.add_sort_field "score desc, #{date_published_field} desc", label: "Relevance"
     config.add_sort_field "#{date_published_field} desc", :label => "Date Published (Newest)"
     config.add_sort_field "#{date_published_field} asc", :label => "Date Published (Oldest)"
     config.add_sort_field "#{title_field} asc", :label => "Title (A-Z)"

--- a/app/indexers/nyc_government_publication_indexer.rb
+++ b/app/indexers/nyc_government_publication_indexer.rb
@@ -10,9 +10,10 @@ class NycGovernmentPublicationIndexer < Hyrax::WorkIndexer
   include Hyrax::IndexesLinkedMetadata
 
   # Uncomment this block if you want to add custom indexing behavior:
-  # def generate_solr_document
-  #  super.tap do |solr_doc|
-  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
-  #  end
-  # end
+  def generate_solr_document
+   super.tap do |solr_doc|
+     solr_doc['title_ssi'] = object.title
+     solr_doc['agency_ssi'] = object.agency
+   end
+  end
 end

--- a/app/indexers/nyc_government_publication_indexer.rb
+++ b/app/indexers/nyc_government_publication_indexer.rb
@@ -14,6 +14,7 @@ class NycGovernmentPublicationIndexer < Hyrax::WorkIndexer
    super.tap do |solr_doc|
      solr_doc['title_ssi'] = object.title
      solr_doc['agency_ssi'] = object.agency
+     solr_doc['date_published_ssi'] = object.date_published
    end
   end
 end

--- a/app/views/records/edit_fields/_date_published.html.erb
+++ b/app/views/records/edit_fields/_date_published.html.erb
@@ -2,7 +2,7 @@
     $('#nyc_government_publication_date_published').inputmask(
         {
             alias: 'datetime',
-            inputFormat: 'mm/dd/yyyy',
+            inputFormat: 'yyyy-mm-dd',
             placeholder: '_',
             showMaskOnHover: false,
             min: '01/01/1600'
@@ -10,4 +10,4 @@
 </script>
 <%= f.input :date_published, as: :string,
             required: f.object.required?(key),
-            input_html: { class: 'form-control', multiple: false, placeholder: 'MM/DD/YYYY' } %>
+            input_html: { class: 'form-control', multiple: false, placeholder: 'YYYY-MM-DD' } %>


### PR DESCRIPTION
This PR adds **Title, Agency, and Date Published** sorting options to the search page.

When saving to Solr, add an extra entry in the document to save Title, Agency, and Date Published as a SSI (String Stored Indexed). By default the custom form fields are saved as TESIM (Text English Stored Indexed Multivalue). Solr is unable sort metadata that is stored as multivalue so we have to create a single value entry in each document. Additionally we have to change the Date Published format from MM/DD/YYYY to YYYY-MM-DD in order to allow for proper alphanumeric sorting.