### PR TITLE
Feature/GPP-286: Submitter Dashboard - Redesign

### DIFF
--- a/app/models/concerns/hydra/role_management/user_roles.rb
+++ b/app/models/concerns/hydra/role_management/user_roles.rb
@@ -1,0 +1,36 @@
+module Hydra
+  module RoleManagement
+    module UserRoles
+      extend ActiveSupport::Concern
+      included do
+        has_and_belongs_to_many :roles
+      end
+
+      def groups
+        g = roles.map(&:name)
+        g += ['registered'] unless new_record? || guest?
+        g
+      end
+
+      def guest?
+        if defined?(DeviseGuests)
+          read_attribute :guest
+        else
+          false
+        end
+      end
+
+      def admin?
+        roles.where(name: 'admin').exists?
+      end
+
+      def agency_submitters?
+        roles.where(name: 'agency_submitters').exists?
+      end
+
+      def library_reviewers?
+        roles.where(name: 'library_reviewers').exists?
+      end
+    end
+  end
+end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,20 +1,31 @@
 <ul id="user_utility_links" class="nav navbar-nav navbar-right">
   <%= render 'shared/locale_picker' if available_translations.size > 1 %>
   <% if user_signed_in? %>
-    <li>
-      <%= render_notifications(user: current_user) %>
-    </li>
-    <li class="dropdown">
-      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false, controls: 'user-util-links' } do %>
-        <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
-        <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
-        <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
-        <span class="fa fa-user" aria-hidden="true"></span>
-        <span class="caret"></span>
-      <% end %>
-      <ul id="user-util-links" class="dropdown-menu dropdown-menu-right" role="menu">
-        <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
-      </ul>
-    </li>
+    <% if current_user.nyc_employee %>
+      <li>
+        <%= render_notifications(user: current_user) %>
+      </li>
+      <li class="dropdown">
+        <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false, controls: 'user-util-links' } do %>
+          <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+          <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+          <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+          <span class="fa fa-user" aria-hidden="true"></span>
+          <span class="caret"></span>
+        <% end %>
+        <ul id="user-util-links" class="dropdown-menu dropdown-menu-right" role="menu">
+          <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
+        </ul>
+      </li>
+    <% else %>
+      <li class="dropdown">
+        <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button' do %>
+          <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+          <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+          <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+          <span class="fa fa-user" aria-hidden="true"></span>
+        <% end %>
+      </li>
+    <% end %>
   <% end %>
 </ul>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -19,7 +19,7 @@
       </li>
     <% else %>
       <li class="dropdown">
-        <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button' do %>
+        <%= link_to '', role: 'button', data: { toggle: 'dropdown' } do %>
           <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
           <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
           <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,0 +1,47 @@
+<div class="show-actions">
+  <% if Hyrax.config.analytics? %>
+    <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+  <% end %>
+  <% if presenter.editor? %>
+    <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
+    <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
+    <% if presenter.member_presenters.size > 1 %>
+      <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
+    <% end %>
+    <% if presenter.valid_child_concerns.length > 0 %>
+      <div class="btn-group">
+        <% if current_user.admin? or current_user.library_reviewers? %>
+          <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Attach Child <span class="caret"></span></button>
+        <% end %>
+        <ul class="dropdown-menu">
+          <% presenter.valid_child_concerns.each do |concern| %>
+            <li>
+              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  <% end %>
+  <% if presenter.show_deposit_for?(collections: @user_collections) %>
+    <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+    <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                   class: 'btn btn-default submits-batches submits-batches-add',
+                   data: { toggle: "modal", target: "#collection-list-container" } %>
+  <% end %>
+  <% if presenter.work_featurable? %>
+    <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),
+                data: { behavior: 'feature' },
+                class: presenter.display_unfeature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+
+    <%= link_to "Unfeature", hyrax.featured_work_path(presenter, format: :json),
+                data: { behavior: 'unfeature' },
+                class: presenter.display_feature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+  <% end %>
+</div>
+
+<!-- COinS hook for Zotero -->
+<span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
+<!-- Render Modals -->
+<%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>

--- a/app/views/hyrax/dashboard/show_user.html.erb
+++ b/app/views/hyrax/dashboard/show_user.html.erb
@@ -1,0 +1,49 @@
+<% provide :page_header do %>
+  <h1><%= t("hyrax.dashboard.title") %></h1>
+<% end %>
+
+<% if current_user.library_reviewers? %>
+  <div class="panel panel-default user-activity">
+    <div class="panel-heading">
+      <h3 class="panel-title "><%= t("hyrax.dashboard.user_activity.title") %></h3>
+    </div>
+    <div class="panel-body">
+      <%= @presenter.render_recent_activity %>
+    </div>
+  </div>
+<% end %>
+
+<div class="panel panel-default" id="notifications">
+  <div class="panel-heading">
+    <h3 class="panel-title "><%= t("hyrax.dashboard.user_notifications") %></h3>
+  </div>
+  <div class="panel-body">
+    <%= @presenter.render_recent_notifications %>
+    <%= @presenter.link_to_additional_notifications %>
+  </div>
+</div>
+
+<% if current_user.library_reviewers? %>
+  <% if Flipflop.proxy_deposit? %>
+    <div class="panel panel-default" id="proxy_management">
+      <div class="panel-heading">
+        <h3 class="panel-title "><%= t("hyrax.dashboard.current_proxies") %></h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'hyrax/dashboard/_index_partials/current_proxy_rights', user: current_user %>
+        <%= @presenter.link_to_manage_proxies %>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
+<% if current_user.library_reviewers? %>
+  <div class="panel panel-default transfers">
+    <div class="panel-heading">
+      <h3 class="panel-title "><%= t("hyrax.dashboard.transfer_of_ownership") %></h3>
+    </div>
+    <div class="panel-body">
+      <%= render 'hyrax/dashboard/_index_partials/transfers', presenter: @presenter.transfers %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hyrax/dashboard/show_user.html.erb
+++ b/app/views/hyrax/dashboard/show_user.html.erb
@@ -1,3 +1,11 @@
+<%
+  # Redirect public users back to the homepage
+  @collection = Collection.first
+  if current_user.has_nyc_account and @collection
+    controller.redirect_to(@collection)
+%>
+<% end %>
+
 <% provide :page_header do %>
   <h1><%= t("hyrax.dashboard.title") %></h1>
 <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -1,0 +1,33 @@
+<% if can? :read, :admin_dashboard %>
+  <li class="h5"><%= t('hyrax.admin.sidebar.activity') %></li>
+
+  <li>
+    <%= menu.collapsable_section t('hyrax.admin.sidebar.user_activity'),
+                                 icon_class: "fa fa-line-chart",
+                                 id: 'collapseUserActivity',
+                                 open: menu.user_activity_section? do %>
+      <%= menu.nav_link(hyrax.dashboard_profile_path(current_user),
+                        also_active_for: hyrax.edit_dashboard_profile_path(current_user)) do %>
+        <span class="fa fa-id-card" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.profile') %></span>
+      <% end %>
+
+      <%= menu.nav_link(hyrax.notifications_path) do %>
+        <span class="fa fa-bell" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.notifications') %></span>
+      <% end %>
+
+      <%= menu.nav_link(hyrax.transfers_path) do %>
+        <span class="fa fa-arrows-h" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.transfers') %></span>
+      <% end %>
+
+      <% if Flipflop.proxy_deposit? %>
+        <%= menu.nav_link(hyrax.depositors_path) do %>
+          <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.dashboard.manage_proxies') %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </li>
+
+  <%= menu.nav_link(hyrax.admin_stats_path) do %>
+    <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.statistics') %></span>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -1,0 +1,13 @@
+<li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
+
+<% if current_user.admin? or current_user.library_reviewers? %>
+  <%= menu.nav_link(hyrax.my_collections_path,
+                    also_active_for: hyrax.dashboard_collections_path) do %>
+    <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+  <% end %>
+<% end %>
+
+<%= menu.nav_link(hyrax.my_works_path,
+                  also_active_for: hyrax.dashboard_works_path) do %>
+  <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
+<% end %>

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -1,0 +1,20 @@
+<table class="table table-striped works-list">
+  <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
+  <thead>
+  <tr>
+    <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
+    <th><%= t("hyrax.dashboard.my.heading.title") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+    <% if current_user.admin? or current_user.library_reviewers? %>
+      <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
+      <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+      <th><%= t("hyrax.dashboard.my.heading.action") %></th>
+    <% end %>
+  </tr>
+  </thead>
+  <tbody>
+  <% docs.each_with_index do |document, counter| %>
+    <%= render 'list_works', document: document, counter: counter, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/my/works/_facets.html.erb
+++ b/app/views/hyrax/my/works/_facets.html.erb
@@ -1,0 +1,9 @@
+<% # main container for facets/limits menu -%>
+<% if has_facet_values? %>
+  <% if current_user.admin? or current_user.library_reviewers? %>
+    <div class="list-filters" role="group">
+      <span class="list-filters-label"><%= t("hyrax.dashboard.my.facet_label.works") %></span>
+      <%= render_facet_partials %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -1,0 +1,42 @@
+<tr id="document_<%= document.id %>">
+
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+    <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
+  </td>
+
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class="date"><%= document.date_uploaded %></td>
+  <% if current_user.admin? or current_user.library_reviewers? %>
+    <td class='text-center'>
+      <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span></td>
+    <td><%= render_visibility_link document %></td>
+
+    <td>
+      <%= render 'work_action_menu', document: document %>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -1,0 +1,66 @@
+<% provide :page_title, t("hyrax.admin.sidebar.works") %>
+
+<% provide :head do %>
+  <%= rss_feed_link_tag route_set: hyrax %>
+  <%= atom_feed_link_tag route_set: hyrax %>
+<% end %>
+
+<script>
+    //<![CDATA[
+
+    <%= render partial: 'scripts', formats: [:js] %>
+
+    //]]>
+</script>
+
+<% provide :page_header do %>
+  <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t("hyrax.admin.sidebar.works") %></h1>
+  <% if current_ability.can_create_any_work? %>
+    <div class="pull-right">
+      <% if @create_work_presenter.many? %>
+        <%# Removed batch upload button here. Refer to /vendor/bundle/ruby/2.5.0/gems/hyrax-2.5.1/app/views/hyrax/my/works/index.html.erb for original code. %>
+        <%= link_to(
+                t(:'helpers.action.work.new'),
+                '#',
+                data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single' },
+                class: 'btn btn-primary'
+            ) %>
+      <% else # simple link to the first work type %>
+        <%# Removed batch upload button here. Refer to /vendor/bundle/ruby/2.5.0/gems/hyrax-2.5.1/app/views/hyrax/my/works/index.html.erb for original code. %>
+        <%= link_to(
+                t(:'helpers.action.work.new'),
+                new_polymorphic_path([main_app, @create_work_presenter.first_model]),
+                class: 'btn btn-primary'
+            ) %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
+      <%= render 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>
+      <div class="panel-heading">
+        <% if current_page?(hyrax.my_works_path(locale: nil)) %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_own', total_count: @response.total_count).html_safe %></span>
+        <% elsif current_page?(hyrax.dashboard_works_path(locale: nil)) && !current_ability.admin? %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_manage', total_count: @response.total_count).html_safe %></span>
+        <% else %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.in_repo', total_count: @response.total_count).html_safe %></span>
+        <% end %>
+      </div>
+      <div class="panel-body">
+        <%= render 'search_header' %>
+        <h2 class="sr-only">Works listing</h2>
+        <%= render 'document_list' %>
+
+        <%= render 'results_pagination' %>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<%= render '/shared/select_work_type_modal', create_work_presenter: @create_work_presenter if @create_work_presenter.many? %>

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -28,8 +28,9 @@
       <% else # simple link to the first work type %>
         <%# Removed batch upload button here. Refer to /vendor/bundle/ruby/2.5.0/gems/hyrax-2.5.1/app/views/hyrax/my/works/index.html.erb for original code. %>
         <%= link_to(
-                t(:'helpers.action.work.new'),
-                new_polymorphic_path([main_app, @create_work_presenter.first_model]),
+                'Submit a Publication',
+                new_polymorphic_path([main_app, @create_work_presenter.first_model],
+                                     add_works_to_collection: Collection.first),
                 class: 'btn btn-primary'
             ) %>
       <% end %>


### PR DESCRIPTION
This PR changes the dashboard to hide certain elements if a user doesn't belong in a certain role. This is mostly done through erb template conditionals such as:

`<% if current_user.admin? %>`
`<% if current_user.library_reviewers? %>`
etc.

Public users are also redirected back to the homepage if they try to access the dashboard. The buttons to go to the dashboard and check notifications are removed from the navbar. This is done by checking if the user `has_nyc_account`.