### PR TITLE
Feature/GPP-284: Session Timeout for SAML Users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,10 @@ end
 
 gem 'riiif', '~> 2.0'
 
+# gem 'auto-session-timeout'
+# gem 'auto-session-timeout-warning'
+gem 'auto-session-timeout-warning', git: 'git@github.com:nycrecords/auto-session-timeout-warning.git'
 gem 'hydra-role-management'
+gem 'jquery-ui-rails'
 gem 'omniauth-saml'
 gem 'dotenv-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -76,8 +76,6 @@ end
 
 gem 'riiif', '~> 2.0'
 
-# gem 'auto-session-timeout'
-# gem 'auto-session-timeout-warning'
 gem 'auto-session-timeout-warning', git: 'git@github.com:nycrecords/auto-session-timeout-warning.git'
 gem 'hydra-role-management'
 gem 'jquery-ui-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ end
 
 gem 'riiif', '~> 2.0'
 
-gem 'auto-session-timeout-warning', git: 'git@github.com:nycrecords/auto-session-timeout-warning.git'
+gem 'auto-session-timeout-warning', git: 'https://github.com/nycrecords/auto-session-timeout-warning.git'
 gem 'hydra-role-management'
 gem 'jquery-ui-rails'
 gem 'omniauth-saml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: git@github.com:nycrecords/auto-session-timeout-warning.git
+  revision: 5b1bb1b2127e25008dc1cacc8169bc9a972e219e
+  specs:
+    auto-session-timeout-warning (1.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -781,6 +787,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  auto-session-timeout-warning!
   bootstrap-sass (~> 3.0)
   byebug
   capybara (~> 2.13)
@@ -795,6 +802,7 @@ DEPENDENCIES
   hyrax (= 2.5.1)
   jbuilder (~> 2.5)
   jquery-rails
+  jquery-ui-rails
   listen (>= 3.0.5, < 3.2)
   omniauth-saml
   puma (~> 3.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:nycrecords/auto-session-timeout-warning.git
+  remote: https://github.com/nycrecords/auto-session-timeout-warning.git
   revision: 5b1bb1b2127e25008dc1cacc8169bc9a972e219e
   specs:
     auto-session-timeout-warning (1.1.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //
 // Required by Blacklight
 //= require jquery
+//= require jquery-ui
 //= require jquery_ujs
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,5 +12,6 @@
  *
  *= require_tree .
  *= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
+ *= require jquery-ui
  *= require_self
  */

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 class ApplicationController < ActionController::Base
+  auto_session_timeout 60.minutes
+  before_timedout_action
+
   helper Openseadragon::OpenseadragonHelper
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  auto_session_timeout 60.minutes
+  auto_session_timeout 30.minutes
   before_timedout_action
 
   helper Openseadragon::OpenseadragonHelper

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,4 +17,12 @@ class SessionsController < Devise::SessionsController
       super
     end
   end
+
+  def active
+    render_session_status
+  end
+
+  def timeout
+    redirect_to user_saml_omniauth_authorize_path(locale: nil) + '/spslo'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,6 @@ class User < ApplicationRecord
   devise_modules = [
     :registerable,
     :recoverable,
-    :rememberable,
     :omniauthable,
     omniauth_providers: [:saml],
     authentication_keys: [:guid]

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -7,7 +7,7 @@
 
   <body>
     <% if current_user %>
-      <%= auto_session_warning_tag %>
+      <%= auto_session_warning_tag message: "Your session will expire in approximately 5 minutes." %>
       <%= auto_session_timeout_js timeout: 1800,
                                   frequency: 60,
                                   start: 60,

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -6,6 +6,15 @@
   </head>
 
   <body>
+    <% if current_user %>
+      <%= auto_session_warning_tag %>
+      <%= auto_session_timeout_js timeout: 1800,
+                                  frequency: 60,
+                                  start: 60,
+                                  warning: 300,
+                                  logoutURL: main_app.destroy_user_session_path %>
+    <% end %>
+
     <div class="skip-to-content">
       <%= link_to "Skip to Content", "#skip-to-content" %>
     </div>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -6,6 +6,15 @@
   </head>
 
   <body class="gpp-dashboard">
+    <% if current_user %>
+      <%= auto_session_warning_tag %>
+      <%= auto_session_timeout_js timeout: 1800,
+                                  frequency: 60,
+                                  start: 60,
+                                  warning: 300,
+                                  logoutURL: main_app.destroy_user_session_path %>
+    <% end %>
+
     <div class="skip-to-content">
       <%= link_to "Skip to Content", "#skip-to-content" %>
     </div>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -7,7 +7,7 @@
 
   <body class="gpp-dashboard">
     <% if current_user %>
-      <%= auto_session_warning_tag %>
+      <%= auto_session_warning_tag message: "Your session will expire in approximately 5 minutes." %>
       <%= auto_session_timeout_js timeout: 1800,
                                   frequency: 60,
                                   start: 60,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
-  
+
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'
-  
+
     concern :searchable, Blacklight::Routes::Searchable.new
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     get 'sign_in', to: 'omniauth#new', as: :new_user_session
     post 'sign_in', to: 'omniauth_callbacks#saml', as: :new_session
     get 'sign_out', to: 'sessions#destroy', as: :destroy_user_session
+    get 'active' => 'sessions#active'
+    get 'timeout' => 'sessions#timeout'
   end
 
   mount Hydra::RoleManagement::Engine => '/'


### PR DESCRIPTION
This PR implements session timeout for authenticated users. 

### Changes:
- Session timeout is handled by the [auto-session-timeout-warning](https://github.com/nycrecords/auto-session-timeout-warning) gem.
- An additional dependency, jquery-ui-rails is required.
- A user's session will automatically timeout after 30 minutes of inactivity. A warning will be displayed 5 minutes before timeout. An AJAX request to `/active` will be sent every 60 seconds to check the server for an active session.