### PR TITLE
Feature/GPP-284: Add Renew Session

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/nycrecords/auto-session-timeout-warning.git
-  revision: 5b1bb1b2127e25008dc1cacc8169bc9a972e219e
+  revision: ce22d3e7233dbd8ed7d982b4b0eab90b62112d86
   specs:
     auto-session-timeout-warning (1.1.0)
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < Devise::SessionsController
+  auto_session_timeout_actions
   SAML_SETTINGS = Devise.omniauth_configs[:saml].strategy
 
   def destroy
@@ -16,10 +17,6 @@ class SessionsController < Devise::SessionsController
     else
       super
     end
-  end
-
-  def active
-    render_session_status
   end
 
   def timeout

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     get 'sign_out', to: 'sessions#destroy', as: :destroy_user_session
     get 'active' => 'sessions#active'
     get 'timeout' => 'sessions#timeout'
+    get 'renew_session' => 'sessions#renew'
   end
 
   mount Hydra::RoleManagement::Engine => '/'


### PR DESCRIPTION
This PR adds the renew_session route required for the latest [commit](https://github.com/nycrecords/auto-session-timeout-warning/commit/ce22d3e7233dbd8ed7d982b4b0eab90b62112d86) of `auto-session-timeout-warning`. This change was made so that a page refresh is not necessary to renew the session timer.