### PR TITLE
Feature/GPP-277: UI updates to record display page

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -284,7 +284,7 @@ module Hyrax
       respond_to do |wants|
         wants.html do
           # Calling `#t` in a controller context does not mark _html keys as html_safe
-          flash[:notice] = "Your files are being processed in the background. You may need to refresh this page to see these updates."
+          flash[:notice] = 'Your files are being processed. You may need to refresh this page to see these updates.'
           redirect_to [main_app, curation_concern]
         end
         wants.json { render :show, status: :created, location: polymorphic_path([main_app, curation_concern]) }

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -26,11 +26,47 @@ class SolrDocument
 
   use_extension( Hydra::ContentNegotiation )
 
-  def date_published
-    self[Solrizer.solr_name('date_published')][0]
+  def sub_title
+    self[Solrizer.solr_name('sub_title')]
   end
 
   def agency
     self[Solrizer.solr_name('agency')][0]
+  end
+
+  def report_type
+    self[Solrizer.solr_name('report_type')]
+  end
+
+  def date_published
+    self[Solrizer.solr_name('date_published')][0]
+  end
+
+  def additional_creators
+    self[Solrizer.solr_name('additional_creators')]
+  end
+
+  def fiscal_year
+    self[Solrizer.solr_name('fiscal_year')]
+  end
+
+  def calendar_year
+    self[Solrizer.solr_name('calendar_year')]
+  end
+
+  def borough
+    self[Solrizer.solr_name('borough')]
+  end
+
+  def school_district
+    self[Solrizer.solr_name('school_district')]
+  end
+
+  def community_board_district
+    self[Solrizer.solr_name('community_board_district')]
+  end
+
+  def associated_place
+    self[Solrizer.solr_name('associated_place')]
   end
 end

--- a/app/presenters/hyrax/nyc_government_publication_presenter.rb
+++ b/app/presenters/hyrax/nyc_government_publication_presenter.rb
@@ -14,7 +14,6 @@ module Hyrax
              :borough,
              :school_district,
              :community_board_district,
-             :associated_place,
-             to: :solr_document
+             :associated_place, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/nyc_government_publication_presenter.rb
+++ b/app/presenters/hyrax/nyc_government_publication_presenter.rb
@@ -1,6 +1,20 @@
+# frozen_string_literal: true
+
 # Generated via
 #  `rails generate hyrax:work NycGovernmentPublication`
 module Hyrax
   class NycGovernmentPublicationPresenter < Hyrax::WorkShowPresenter
+    delegate :sub_title,
+             :report_type,
+             :date_published,
+             :fiscal_year,
+             :calendar_year,
+             :agency,
+             :additional_creators,
+             :borough,
+             :school_district,
+             :community_board_district,
+             :associated_place,
+             to: :solr_document
   end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,4 +1,6 @@
-<%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
+<% if user_signed_in? && (current_user.admin? || current_user.library_reviewers?) %>
+  <%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
+<% end %>
 <%= presenter.attribute_to_html(:sub_title, html_dl: true) %>
 <%= presenter.attribute_to_html(:agency, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:additional_creators, html_dl: true) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,0 +1,14 @@
+<%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
+<%= presenter.attribute_to_html(:sub_title, html_dl: true) %>
+<%= presenter.attribute_to_html(:agency, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:additional_creators, html_dl: true) %>
+<%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:report_type, html_dl: true) %>
+<%= presenter.attribute_to_html(:date_published, html_dl: true) %>
+<%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:fiscal_year, html_dl: true) %>
+<%= presenter.attribute_to_html(:calendar_year, html_dl: true) %>
+<%= presenter.attribute_to_html(:borough, html_dl: true) %>
+<%= presenter.attribute_to_html(:school_district, html_dl: true) %>
+<%= presenter.attribute_to_html(:community_board_district, html_dl: true) %>
+<%= presenter.attribute_to_html(:associated_place, html_dl: true) %>

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,0 +1,29 @@
+<h2><%= t('.header') %></h2>
+<%  array_of_ids = presenter.list_of_item_ids_to_display %>
+<%  members = presenter.member_presenters_for(array_of_ids) %>
+<% if members.present? %>
+  <table class="table table-striped related-files">
+    <thead>
+    <tr>
+      <th><%= t('.thumbnail') %></th>
+      <th><%= t('.title') %></th>
+      <th><%= t('.date_uploaded') %></th>
+      <th><%= t('.actions') %></th>
+    </tr>
+    </thead>
+    <tbody>
+    <%= render partial: 'member', collection: members %>
+    </tbody>
+  </table>
+  <div class="row">
+    <% if presenter.total_pages > 1 %>
+      <div class="row record-padding col-md-9">
+        <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+      </div><!-- /pager -->
+    <% end %>
+  </div>
+<% elsif can? :edit, presenter.id %>
+  <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>
+<% else %>
+  <div class="alert alert-warning" role="alert"><%= t('.unauthorized', type: presenter.human_readable_type) %></div>
+<% end %>

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -1,0 +1,10 @@
+<tr class="<%= dom_class(member) %> attributes">
+  <td class="thumbnail">
+    <%= render_thumbnail_tag member %>
+  </td>
+  <td class="attribute attribute-filename ensure-wrapped"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
+  <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>
+  <td>
+    <%= render 'actions', member: member %>
+  </td>
+</tr>

--- a/app/views/hyrax/base/_work_title.erb
+++ b/app/views/hyrax/base/_work_title.erb
@@ -1,0 +1,20 @@
+<% presenter.title.each_with_index do |title, index| %>
+  <div class="row">
+    <div class="col-sm-8">
+      <% if index == 0 %>
+        <h2><%= title %>
+          <% if user_signed_in? && (current_user.admin? || current_user.library_reviewers?) %>
+            <small class="text-muted"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></small>
+          <% end %>
+        </h2>
+      <% else %>
+        <h2><%= title %></h2>
+      <% end %>
+    </div>
+    <div class="col-sm-4 text-right">
+      <% if index == 0 %>
+        <%= render "show_actions", presenter: presenter %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -14,7 +14,9 @@
       </div>
       <div class="panel-body">
         <div class="row">
-          <%= render 'workflow_actions_widget', presenter: @presenter %>
+          <% if @presenter.workflow.state != 'deposited' %>
+            <%= render 'workflow_actions_widget', presenter: @presenter %>
+          <% end %>
           <% if @presenter.iiif_viewer? %>
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,0 +1,40 @@
+<% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
+<div class="row work-type">
+  <div class="col-xs-12">
+    <%= render 'work_type', presenter: @presenter %>
+  </div>
+  <div class="col-xs-12">&nbsp;</div>
+  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <%= render 'work_title', presenter: @presenter %>
+      </div>
+      <div class="panel-body">
+        <div class="row">
+          <%= render 'workflow_actions_widget', presenter: @presenter %>
+          <% if @presenter.iiif_viewer? %>
+            <div class="col-sm-12">
+              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+            </div>
+          <% end %>
+          <div class="col-sm-3 text-center">
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
+          </div>
+          <div class="col-sm-9">
+            <%= render 'work_description', presenter: @presenter %>
+            <%= render 'metadata', presenter: @presenter %>
+          </div>
+          <div class="col-sm-12">
+            <%= render 'items', presenter: @presenter %>
+            <%# TODO: we may consider adding these partials in the future %>
+            <%# = render 'sharing_with', presenter: @presenter %>
+            <%# = render 'user_activity', presenter: @presenter %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/spec/presenters/hyrax/nyc_government_publication_presenter_spec.rb
+++ b/spec/presenters/hyrax/nyc_government_publication_presenter_spec.rb
@@ -1,9 +1,44 @@
+# frozen_string_literal: true
+
 # Generated via
 #  `rails generate hyrax:work NycGovernmentPublication`
 require 'rails_helper'
 
 RSpec.describe Hyrax::NycGovernmentPublicationPresenter do
-  it "has tests" do
-    skip "Add your tests here"
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:ability) { double 'Ability' }
+  let(:presenter) { described_class.new(solr_document, ability) }
+  let(:attributes) { file.to_solr }
+
+  let(:file) do
+    NycGovernmentPublication.new(
+      id: '123abc',
+      depositor: user.user_key,
+      label: 'filename.pdf'
+    )
   end
+  let(:user) { double(user_key: 'test@example.com') }
+  let(:solr_properties) do
+    %w[sub_title report_type date_published fiscal_year calendar_year agency additional_creators borough school_district community_board_district associated_place]
+  end
+  subject { presenter }
+
+  it 'delegate to the solr_document' do
+    solr_properties.each do |property|
+      expect(solr_document).to receive(property.to_sym)
+      presenter.send(property)
+    end
+  end
+
+  it { is_expected.to delegate_method(:sub_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:report_type).to(:solr_document) }
+  it { is_expected.to delegate_method(:date_published).to(:solr_document) }
+  it { is_expected.to delegate_method(:fiscal_year).to(:solr_document) }
+  it { is_expected.to delegate_method(:calendar_year).to(:solr_document) }
+  it { is_expected.to delegate_method(:agency).to(:solr_document) }
+  it { is_expected.to delegate_method(:additional_creators).to(:solr_document) }
+  it { is_expected.to delegate_method(:borough).to(:solr_document) }
+  it { is_expected.to delegate_method(:school_district).to(:solr_document) }
+  it { is_expected.to delegate_method(:community_board_district).to(:solr_document) }
+  it { is_expected.to delegate_method(:associated_place).to(:solr_document) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'rspec/matchers'
+require 'shoulda/matchers'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'active_fedora/cleaner'
@@ -35,6 +36,14 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
This PR updates the show page with UI changes and display metadata for `NycGovernmentPublication`.

Used https://samvera.github.io/customize-metadata-show-page.html for reference.

### Changes:
- 'shoulda/matchers' and `Shoulda::Matchers.configure` is added to `rails_helper.rb` for [delegate_method](https://github.com/thoughtbot/shoulda-matchers/blob/master/lib/shoulda/matchers/independent/delegate_method_matcher.rb).