### PR TITLE
Feature/GPP-303: On login, go to homepage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,4 +14,9 @@ class ApplicationController < ActionController::Base
   with_themed_layout '1_column'
 
   protect_from_forgery with: :exception, except: [:saml]
+
+  # Redirect to location that triggered authentication or to homepage
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) || root_path
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController do
+  let(:user) do
+    User.new(email: 'test@example.com') { |u| u.save!(validate: false) }
+  end
+
+  describe 'After sign-in' do
+    it 'redirects to homepage' do
+      controller.after_sign_in_path_for(user).should == root_path
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `after_sign_in_path_for` method to `ApplicationController`, which redirects user to the location that triggered authentication or to the application root.

See devise [documentation](https://github.com/plataformatec/devise/wiki/How-To:-redirect-to-a-specific-page-on-successful-sign-in) for reference.