### PR TITLE
Feature/GPP-279: Contact Page Redo

### DIFF
--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,6 +1,6 @@
 <h1>
   Contact Us
 </h1>
-
+<br>
 <p>Please send an email to municipal-library-admins at records dot nyc dot gov to ask questions about the Government
   Publications Portal or provide feedback.</p>

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,41 +1,6 @@
-<div class="alert alert-info">
-  <%= render 'directions' %>
-</div>
-
 <h1>
-  <%= t('hyrax.contact_form.header') %>
+  Contact Us
 </h1>
 
-<% if user_signed_in? %>
-  <% nm = current_user.name %>
-  <% em = current_user.email %>
-<% else %>
-  <% nm = '' %>
-  <% em = '' %>
-<% end %>
-
-<%= form_for @contact_form, url: hyrax.contact_form_index_path,
-             html: { class: 'form-horizontal' } do |f| %>
-  <%= f.text_field :contact_method, class: 'hide' %>
-  <div class="form-group">
-    <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :message, t('hyrax.contact_form.message_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
-  </div>
-
-  <%= f.submit value: t('hyrax.contact_form.button_label'), class: "btn btn-primary" %>
-<% end %>
+<p>Please send an email to municipal-library-admins at records dot nyc dot gov to ask questions about the Government
+  Publications Portal or provide feedback.</p>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -47,6 +47,8 @@ en:
           title_tesim: Title
   hyrax:
     account_name: My Institution Account Id
+    controls:
+      contact: Contact Us
     directory:
       suffix: "@example.org"
     footer:


### PR DESCRIPTION
Removed contact form and re did page to look like current DSpace GPP contact page.