### PR TITLE
Bugfix/GPP-304: Change User Identifier in Adding User to Roles from GUID to Email

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    bootstrap_form (4.2.0)
+    bootstrap_form (4.3.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
     breadcrumbs_on_rails (3.0.1)
@@ -325,10 +325,12 @@ GEM
     hydra-pcdm (1.0.1)
       active-fedora (>= 10, < 13)
       mime-types (>= 1)
-    hydra-role-management (1.0.0)
+    hydra-role-management (1.0.2)
       blacklight
       bootstrap_form
+      bundler (>= 1.5)
       cancancan
+      json (>= 1.8)
     hydra-works (1.1.0)
       activesupport (>= 4.2.10, < 6.0)
       hydra-derivatives (~> 3.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
     :recoverable,
     :omniauthable,
     omniauth_providers: [:saml],
-    authentication_keys: [:guid]
+    authentication_keys: [:email]
   ]
 
   devise(*devise_modules)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -40,7 +40,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:email]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -208,7 +208,6 @@ Devise.setup do |config|
   #
   # Defines which key will be used when recovering the password for an account
   # config.reset_password_keys = [:email]
-  config.authentication_keys = [:guid]
 
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to


### PR DESCRIPTION
This PR reverts the devise configuration `authentication_keys` value to `[:email]`. The method `user.user_key` is used as the user identifier in places such as roles and notifications. It is defined by first `authentication_keys` value as found [here](https://github.com/projectblacklight/blacklight-access_controls/blob/master/lib/blacklight/access_controls/user.rb#L19-L21).