### PR TITLE
Bugfix/GPP-304: Only need role in Collection Managers for notifications

### DIFF
--- a/app/services/hyrax/workflow/changes_required_notification.rb
+++ b/app/services/hyrax/workflow/changes_required_notification.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Workflow
+    class ChangesRequiredNotification < GppNotification
+      def workflow_recipients
+        { to: library_reviewers << depositor }
+      end
+
+      def subject
+        'Your deposit requires changes'
+      end
+
+      def message
+        "#{title} (#{link_to work_id, document_path}) requires additional changes before approval.\n\n '#{comment}'"
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/deposited_notification.rb
+++ b/app/services/hyrax/workflow/deposited_notification.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Workflow
+    class DepositedNotification < GppNotification
+      def workflow_recipients
+        { to: library_reviewers << depositor }
+      end
+
+      def subject
+        'Deposit has been approved'
+      end
+
+      def message
+        "#{title} (#{link_to work_id, document_path}) was approved by #{user.user_key}. #{comment}"
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/gpp_notification.rb
+++ b/app/services/hyrax/workflow/gpp_notification.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Workflow
+    # GppNotification is a subclass of AbstractNotification and uses workflow_recipients to override recipients from
+    # NotificationService.
+    class GppNotification < AbstractNotification
+      def initialize(entity, comment, user, recipients = {})
+        recipients ||= {}
+        super
+        @recipients = workflow_recipients.with_indifferent_access
+      end
+
+      def self.send_notification(entity:, comment:, user:, recipients: {})
+        super
+      end
+
+      def workflow_recipients
+        raise NotImplementedError, 'Implement workflow_recipients in a child class'
+      end
+
+      # Users in the role library_reviewers
+      def library_reviewers
+        Role.find_by(name: 'library_reviewers').users.to_a
+      end
+
+      # User who deposited the work
+      def depositor
+        ::User.where(email: document.depositor).first
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/pending_review_notification.rb
+++ b/app/services/hyrax/workflow/pending_review_notification.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Workflow
+    class PendingReviewNotification < GppNotification
+      def workflow_recipients
+        { to: library_reviewers << depositor }
+      end
+
+      def subject
+        'Deposit needs review'
+      end
+
+      def message
+        "#{title} (#{link_to work_id, document_path}) was deposited by #{user.user_key} and is awaiting approval #{comment}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR creates the subclass `GppNotification` to override `recipients` from `NotificationService`.  Notification recipients are generated via `workflow_recipients` in subclasses of `GppNotification`. Emails in the workflow process are now sent to users in the library_reviewer role and depositor.