### PR TITLE
Feature/OP-281: PO Approval Changes to Emails

### DIFF
--- a/app/services/hyrax/workflow/changes_required_notification.rb
+++ b/app/services/hyrax/workflow/changes_required_notification.rb
@@ -14,8 +14,9 @@ module Hyrax
       def message
         "You submitted: #{title}<br><br>" +
             "Your submission has been rejected by the Municipal Library Staff with the following explanation:<br><br>" +
-            "#{comment}<br><br>" +
-            "Your submission has not been deleted. You can access your submission at #{link_to work_id, document_url}, or in the 'Works' section of the Dashboard.<br><br>" +
+            "<strong>#{comment}</strong><br><br>" +
+            "Your submission has not been deleted. You can access your submission #{link_to "here", document_url}, or in the 'Works' section of the Dashboard.<br><br>" +
+            "To make changes, click 'Edit', make the required change, and click 'Save Changes'. Then click 'Review and Approval', choose 'Request Review' and click 'Submit'.<br><br>" +
             "Emails to this mailbox are not monitored. Please contact the Municipal Library at municipal-library-admins@records.nyc.gov.<br><br>" +
             "Thank you,<br>" +
             "Municipal Library"

--- a/app/services/hyrax/workflow/pending_review_notification.rb
+++ b/app/services/hyrax/workflow/pending_review_notification.rb
@@ -8,7 +8,7 @@ module Hyrax
       end
 
       def subject
-        'You have a new task'
+        'Government Publications Portal: You have a new task'
       end
 
       def message

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -58,6 +58,10 @@ en:
     institution_name_full: The Institution Name
     product_name: Government Publications Portal
     product_twitter_handle: "@SamveraRepo"
+  mailboxer:
+    message_mailer:
+      subject_new: "%{subject}"
+      subject_reply: "%{subject}"
   simple_form:
     hints:
       admin_set:


### PR DESCRIPTION
Slight changes to the changes required email notification and removed `Mailboxer new message:` from subject line in all emails.