### PR TITLE
Change NYC.gov header to remove login button

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -2,4 +2,8 @@ class OmniauthController < Devise::SessionsController
   def new
     redirect_to user_saml_omniauth_authorize_path
   end
+
+  def profile
+    redirect_to ENV['NYC_ID_WEB_SERVICES_URL']
+  end
 end

--- a/app/views/_nycid_header.html.erb
+++ b/app/views/_nycid_header.html.erb
@@ -1,6 +1,6 @@
 <div class="nycidm-header">
   <div class="upper-header-black">
-    <div class="container-nycidm">
+    <div>
       <span class="upper-header-left">
       <a href="http://www1.nyc.gov/"><img class="small-nyc-logo" alt="" src="/nyc_white@x2.png"></a>
       <img class="vert-divide" alt="" src="/upper-header-divider.gif">
@@ -8,25 +8,6 @@
           Government Publications Portal
         </span>
       </span>
-
-      <% if user_signed_in? == false %>
-        <span class="upper-header-right">
-          <span class="upper-header-a">
-            <%= link_to t("hyrax.toolbar.profile.login"), main_app.new_user_session_path %>
-          </span>
-        </span>
-      <% else %>
-        <span class="upper-header-right">
-          <span class="upper-header-a">
-            <%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path,
-                id: "logout" %>
-          </span>
-        </span>
-        <img class="vert-divide-right" alt="" src="/upper-header-divider.gif">
-        <span class="upper-header-b">
-          <a id="profile-link" href="#">Profile</a>
-        </span>
-      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -15,7 +15,7 @@
         <% end %>
         <ul id="user-util-links" class="dropdown-menu dropdown-menu-right" role="menu">
           <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
-          <li><%= link_to "Profile", ENV['NYC_ID_WEB_SERVICES_URL'] + "account/user/profile.htm?target=" + ENV['RAILS_HOST'] + url_for(hyrax.dashboard_path) %></li>
+<!--          <li><%#= link_to "Profile", ENV['NYC_ID_WEB_SERVICES_URL'] + "account/user/profile.htm?target=" + ENV['RAILS_HOST'] + url_for(hyrax.dashboard_path) %></li>-->
           <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
         </ul>
       </li>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -6,7 +6,7 @@
         <%= render_notifications(user: current_user) %>
       </li>
       <li class="dropdown">
-        <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false, controls: 'user-util-links' } do %>
+        <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: {toggle: 'dropdown'}, aria: {haspopup: true, expanded: false, controls: 'user-util-links'} do %>
           <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
           <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
           <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
@@ -15,11 +15,13 @@
         <% end %>
         <ul id="user-util-links" class="dropdown-menu dropdown-menu-right" role="menu">
           <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
+          <li><%= link_to "Profile", ENV['NYC_ID_WEB_SERVICES_URL'] + "account/user/profile.htm?target=" + ENV['RAILS_HOST'] + url_for(hyrax.dashboard_path) %></li>
+          <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
         </ul>
       </li>
     <% else %>
       <li class="dropdown">
-        <%= link_to '', role: 'button', data: { toggle: 'dropdown' } do %>
+        <%= link_to '', role: 'button', data: {toggle: 'dropdown'} do %>
           <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
           <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
           <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
@@ -27,5 +29,10 @@
         <% end %>
       </li>
     <% end %>
+  <% else %>
+    <li class="nav-item">
+      <%= link_to t("hyrax.toolbar.profile.login"), main_app.new_user_session_path, role: 'button' %>
+    </li>
   <% end %>
+
 </ul>

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -1,0 +1,16 @@
+<li class="nav-item dropdown" aria-label="Edit language">
+  <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="language-dropdown-menu">
+    <span class="sr-only"><%= t('hyrax.toolbar.language_switch') %></span>
+    <span title="<%= t('hyrax.toolbar.language_switch') %>"><%= available_translations[I18n.locale.to_s] %></span>
+    <b class="caret"></b>
+  </a>
+  <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
+    <li role="presentation" class="dropdown-header"><%= t('hyrax.toolbar.language_switch') %></li>
+    <li role="presentation" class="divider"></li>
+    <% available_translations.each do |language, label| %>
+      <li role="presentation" lang="<%= language %>">
+        <%= link_to label, "?locale=#{language}", class: 'dropdown-item', role: 'menuitem', tabindex: '-1', data: { locale: language } %>
+      </li>
+    <% end %>
+  </ul>
+</li>


### PR DESCRIPTION
Moves login and logout to the main nav. 

Updates language menu and includes in GPP-hyrax for later modification.