### PR TITLE
Feature/GPP-293: Add focus to error div on new required report form

### DIFF
--- a/app/assets/javascripts/required_reports.js
+++ b/app/assets/javascripts/required_reports.js
@@ -31,6 +31,7 @@ $(document).ready(function () {
         if (local_law_value_length === 0 && charter_and_code_value_length === 0) {
             errorDiv.text('One of Local Law or Charter and Code is required.');
             errorDiv.show();
+            errorDiv.focus();
 
             return false;
         }
@@ -41,6 +42,7 @@ $(document).ready(function () {
             if (frequency_value_length === 0 || frequency_integer_value_length === 0) {
                 errorDiv.text('Frequency and Frequency Integer or Other frequency description is required.');
                 errorDiv.show();
+                errorDiv.focus();
 
                 return false;
             }
@@ -50,6 +52,7 @@ $(document).ready(function () {
             if (frequency_value_length > 0 || frequency_integer_value_length > 0) {
                 errorDiv.text('Frequency and Frequency Integer or Other frequency description is required.');
                 errorDiv.show();
+                errorDiv.focus();
 
                 return false;
             }

--- a/app/views/required_reports/_form.html.erb
+++ b/app/views/required_reports/_form.html.erb
@@ -13,7 +13,7 @@
     </div>
   <% end %>
 
-  <div class="alert alert-danger" id="alert-error" role="alert" style="display: none;"></div>
+  <div class="alert alert-danger" id="alert-error" role="alert" style="display: none;" tabindex="0"></div>
 
   <%= f.input :name,
               as: :string,


### PR DESCRIPTION
Page focus is applied to the error div when an error occurs. This allow the page to scroll up on smaller screens.