### PR TITLE
Feature/GPP-293: Remove edit button and add word-break to required_reports show

### DIFF
--- a/app/views/required_reports/show.html.erb
+++ b/app/views/required_reports/show.html.erb
@@ -10,7 +10,7 @@
   <%= @required_report.name %>
 </p>
 
-<p>
+<p style="word-break: break-all">
   <strong>Description:</strong>
   <%= @required_report.description %>
 </p>
@@ -55,5 +55,5 @@
   <%= @required_report.last_published_date %>
 </p>
 
-<%= link_to 'Edit', edit_required_report_path(@required_report) %> |
+<!--<%#= link_to 'Edit', edit_required_report_path(@required_report) %> |-->
 <%= link_to 'Back', required_reports_path %>


### PR DESCRIPTION
This PR removes the edit button on and adds word-break to the description field on the `views/required_reports/show.html.erb` page.