### PR TITLE
Feature/GPP-293: Add word-wrap to description column in required_reports index page

### DIFF
--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -237,3 +237,11 @@ body.gpp-dashboard {
   border-radius: 10px !important;
   width: 50%;
 }
+
+#required-report-table {
+  .wrap-text {
+    overflow: hidden;
+    max-width: 250px;
+    word-wrap: break-word;
+  }
+}

--- a/app/views/required_reports/index.html.erb
+++ b/app/views/required_reports/index.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div class="table-responsive">
-  <table class="table table-striped table-bordered">
+  <table id="required-report-table" class="table table-striped table-bordered">
     <thead>
     <tr>
       <th>Agency</th>
@@ -34,7 +34,7 @@
       <tr>
         <td><%= required_report.agency %></td>
         <td><%= required_report.name %></td>
-        <td><%= required_report.description %></td>
+        <td class="wrap-text"><%= required_report.description %></td>
         <td><%= required_report.local_law %></td>
         <td><%= required_report.charter_and_code %></td>
         <td><%= required_report.frequency %></td>


### PR DESCRIPTION
This PR adds word-wrap to the description column values on the `views/required_reports/index.html.erb` page.

### Changes:
- Add `wrap-text` style class to `gpp.scss` for word-wrap feature.