### PR TITLE
Feature/GPP-338: Change "Start date” to only be required if “Frequency” is provided and add "Once" to frequencies

### DIFF
--- a/app/assets/javascripts/required_reports.js
+++ b/app/assets/javascripts/required_reports.js
@@ -25,6 +25,7 @@ $(document).ready(function () {
             frequency_value_length = $('#required_report_frequency').val().length,
             frequency_integer_value_length = $('#required_report_frequency_integer').val().length,
             other_frequency_description_value_length = $('#required_report_other_frequency_description').val().length,
+            start_date = $('#required_report_start_date').val().length,
             errorDiv = $('#new_required_report #alert-error');
 
         // Validate one of local_law or charter_and_code is provided
@@ -39,8 +40,8 @@ $(document).ready(function () {
         // other_frequency_description is empty
         if (other_frequency_description_value_length === 0) {
             // One of frequency or frequency_integer is empty
-            if (frequency_value_length === 0 || frequency_integer_value_length === 0) {
-                errorDiv.text('Frequency and Frequency Integer or Other frequency description is required.');
+            if (frequency_value_length === 0 || frequency_integer_value_length === 0 || start_date === 0) {
+                errorDiv.text('Frequency, Frequency Integer and Start Date or Other frequency description is required.');
                 errorDiv.show();
                 errorDiv.focus();
 

--- a/app/views/required_reports/_form.html.erb
+++ b/app/views/required_reports/_form.html.erb
@@ -62,8 +62,7 @@
 
   <%= f.input :start_date,
               as: :string,
-              input_html: { class: 'form-control', multiple: false, placeholder: 'YYYY-MM-DD' },
-              required: true
+              input_html: { class: 'form-control', multiple: false, placeholder: 'YYYY-MM-DD' }
   %>
 
   <%= f.input :end_date,

--- a/config/authorities/frequencies.yml
+++ b/config/authorities/frequencies.yml
@@ -7,3 +7,5 @@ terms:
     term: Every X Weeks
   - id: Every X Days
     term: Every X Days
+  - id: Once
+    term: Once

--- a/db/migrate/20191031204401_create_required_reports.rb
+++ b/db/migrate/20191031204401_create_required_reports.rb
@@ -9,7 +9,7 @@ class CreateRequiredReports < ActiveRecord::Migration[5.1]
       t.string :frequency
       t.integer :frequency_integer
       t.string :other_frequency_description
-      t.date :start_date, null: false
+      t.date :start_date
       t.date :end_date
       t.date :last_published_date
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -312,7 +312,7 @@ ActiveRecord::Schema.define(version: 20191106182840) do
     t.string "frequency"
     t.integer "frequency_integer"
     t.string "other_frequency_description"
-    t.date "start_date", null: false
+    t.date "start_date"
     t.date "end_date"
     t.date "last_published_date"
     t.datetime "created_at", null: false


### PR DESCRIPTION
This PR changes `start_date` in `required_reports` table to be nullable.

Changes:
- `start_date` in `required_reports` table is nullable.
- Add validation to require "Start date" if "Frequency" is provided on Add Report form.
- Add "Once" to frequencies controlled vocabulary.