### PR TITLE
Feature/GPP-324: Automating Frequency Calculations for RequiredReports Added Via UI

### DIFF
--- a/app/controllers/required_reports_controller.rb
+++ b/app/controllers/required_reports_controller.rb
@@ -33,6 +33,7 @@ class RequiredReportsController < ApplicationController
     start_date = Date.parse(required_report_params['start_date'])
     end_date = Date.parse(required_report_params['end_date']) unless required_report_params['end_date'].blank?
 
+    # Get attributes for RequiredReportDueDate
     due_date_attributes = RequiredReportDueDate.new.generate_due_date_attributes(frequency,
                                                                                  frequency_integer,
                                                                                  start_date,

--- a/app/controllers/required_reports_controller.rb
+++ b/app/controllers/required_reports_controller.rb
@@ -33,12 +33,13 @@ class RequiredReportsController < ApplicationController
     start_date = Date.parse(required_report_params['start_date'])
     end_date = Date.parse(required_report_params['end_date']) unless required_report_params['end_date'].blank?
 
-    # Get attributes for RequiredReportDueDate
+    # Get attributes for RequiredReportDueDate.
     due_date_attributes = RequiredReportDueDate.new.generate_due_date_attributes(frequency,
                                                                                  frequency_integer,
                                                                                  start_date,
                                                                                  end_date)
 
+    # Return new RequiredReport object with required_report_due_dates_attributes added to params.
     @required_report = RequiredReport.new(required_report_params.merge(required_report_due_dates_attributes:
                                                                          due_date_attributes))
 

--- a/app/controllers/required_reports_controller.rb
+++ b/app/controllers/required_reports_controller.rb
@@ -28,6 +28,14 @@ class RequiredReportsController < ApplicationController
   def create
     @required_report = RequiredReport.new(required_report_params)
 
+    frequency = required_report_params['frequency']
+    frequency_integer = required_report_params['frequency_integer']
+    start_date = required_report_params['start_date']
+    end_date = required_report_params['end_date']
+
+    frequency_calculation = FrequencyCalculation.new
+    due_dates = frequency_calculation.calculate(frequency, frequency_integer, start_date, end_date)
+
     respond_to do |format|
       if @required_report.save
         format.html { redirect_to @required_report, notice: 'Required report was successfully created.' }

--- a/app/models/required_report.rb
+++ b/app/models/required_report.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 class RequiredReport < ApplicationRecord
   has_many :required_report_due_dates
   belongs_to :agency, foreign_key: 'agency_name', primary_key: 'name'
+
+  accepts_nested_attributes_for :required_report_due_dates
 
   # Convert empty name and agency fields to null
   nilify_blanks only: [:name, :agency]

--- a/app/models/required_report_due_date.rb
+++ b/app/models/required_report_due_date.rb
@@ -3,6 +3,9 @@
 class RequiredReportDueDate < ApplicationRecord
   belongs_to :required_report
 
+  # Generates and returns attributes for parent class: an array of hashes with 'due_date' key.
+  # Ex:
+  #     [ { due_date: 2020-01-01 }, { due_date: 2020-02-01 }, ... ]
   def generate_due_date_attributes(frequency, frequency_integer, start_date, end_date)
     frequency_calculation = FrequencyCalculation.new
     due_dates = frequency_calculation.calculate(frequency, frequency_integer, start_date, end_date)

--- a/app/models/required_report_due_date.rb
+++ b/app/models/required_report_due_date.rb
@@ -1,3 +1,11 @@
+# frozen_string_literal: true
+
 class RequiredReportDueDate < ApplicationRecord
   belongs_to :required_report
+
+  def generate_due_date_attributes(frequency, frequency_integer, start_date, end_date)
+    frequency_calculation = FrequencyCalculation.new
+    due_dates = frequency_calculation.calculate(frequency, frequency_integer, start_date, end_date)
+    due_dates.map { |d| { due_date: d } }
+  end
 end

--- a/lib/frequency_calculation.rb
+++ b/lib/frequency_calculation.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class FrequencyCalculation
+  def initialize
+    @calendar = Rails.configuration.calendar
+  end
+
+  def calculate(frequency, frequency_integer, start_date, end_date)
+    dates = []
+    date = start_date
+    frequency_symbol = get_frequency_symbol(frequency)
+
+    while date < end_date
+      date = date.advance(frequency_symbol => frequency_integer)
+      date = @calendar.roll_forward(date)
+      dates << date
+    end
+
+    dates
+  end
+
+  def calculate_end_date(start_date, end_date)
+    end_date_from_start_date = start_date + 3.years
+
+    return end_date_from_start_date if end_date.nil?
+
+    end_date < end_date_from_start_date ? end_date : end_date_from_start_date
+    end
+  end
+
+  def get_frequency_symbol(frequency)
+    string_to_symbol = {
+      'Every X Years' => 'years',
+      'Every X Months' => 'months',
+      'Every X Weeks' => 'weeks',
+      'Every X Days' => 'days'
+    }
+
+    string_to_symbol[frequency].to_sym
+  end
+end

--- a/lib/frequency_calculation.rb
+++ b/lib/frequency_calculation.rb
@@ -6,17 +6,20 @@ class FrequencyCalculation
   end
 
   def calculate(frequency, frequency_integer, start_date, end_date)
-    dates = []
+    dates = [@calendar.roll_forward(start_date)]
+
+    return dates if frequency == 'Once'
+
     date = start_date
+    end_date = calculate_end_date(start_date, end_date)
     frequency_symbol = get_frequency_symbol(frequency)
 
     while date < end_date
       date = date.advance(frequency_symbol => frequency_integer)
-      date = @calendar.roll_forward(date)
-      dates << date
+      dates << @calendar.roll_forward(date)
     end
 
-    dates
+    dates.uniq
   end
 
   def calculate_end_date(start_date, end_date)

--- a/lib/frequency_calculation.rb
+++ b/lib/frequency_calculation.rb
@@ -25,7 +25,6 @@ class FrequencyCalculation
     return end_date_from_start_date if end_date.nil?
 
     end_date < end_date_from_start_date ? end_date : end_date_from_start_date
-    end
   end
 
   def get_frequency_symbol(frequency)

--- a/lib/frequency_calculation.rb
+++ b/lib/frequency_calculation.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+# Class for calculating due dates of required reports.
 class FrequencyCalculation
   def initialize
     @calendar = Rails.configuration.calendar
   end
 
+  # Returns an array of unique due dates.
   def calculate(frequency, frequency_integer, start_date, end_date)
     dates = [@calendar.roll_forward(start_date)]
 
@@ -22,6 +24,7 @@ class FrequencyCalculation
     dates.uniq
   end
 
+  # Returns an end_date, the date to stop calculating until.
   def calculate_end_date(start_date, end_date)
     end_date_from_start_date = start_date + 3.years
 
@@ -30,6 +33,8 @@ class FrequencyCalculation
     end_date < end_date_from_start_date ? end_date : end_date_from_start_date
   end
 
+  # Returns a symbol given a value from FrequenciesService.
+  # Symbol is to be used as a parameter in Date.advance method.
   def get_frequency_symbol(frequency)
     string_to_symbol = {
       'Every X Years' => 'years',


### PR DESCRIPTION
This PR includes the implementation of the `FrequencyCalculation` class to calculate due dates of required reports given the frequency, frequency_integer, start_date and end_date (optional).

### Changes:
- Add `accepts_nested_attributes_for` class method to `RequiredReport` model to allow for saving of child, `required_report_due_dates`, records.
- Add `generate_due_date_attributes` instance method to `RequiredReportDueDate` model to generate attributes to be saved by the parent, `RequiredReport`.