### PR TITLE
Move parameter type conversions to RequiredReportDueDate model

### DIFF
--- a/app/controllers/required_reports_controller.rb
+++ b/app/controllers/required_reports_controller.rb
@@ -28,16 +28,11 @@ class RequiredReportsController < ApplicationController
   # POST /required_reports
   # POST /required_reports.json
   def create
-    frequency = required_report_params['frequency']
-    frequency_integer = required_report_params['frequency_integer'].to_i
-    start_date = Date.parse(required_report_params['start_date'])
-    end_date = Date.parse(required_report_params['end_date']) unless required_report_params['end_date'].blank?
-
     # Get attributes for RequiredReportDueDate.
-    due_date_attributes = RequiredReportDueDate.new.generate_due_date_attributes(frequency,
-                                                                                 frequency_integer,
-                                                                                 start_date,
-                                                                                 end_date)
+    due_date_attributes = RequiredReportDueDate.new.generate_due_date_attributes(required_report_params[:frequency],
+                                                                                 required_report_params[:frequency_integer],
+                                                                                 required_report_params[:start_date],
+                                                                                 required_report_params[:end_date])
 
     # Return new RequiredReport object with required_report_due_dates_attributes added to params.
     @required_report = RequiredReport.new(required_report_params.merge(required_report_due_dates_attributes:

--- a/app/models/required_report_due_date.rb
+++ b/app/models/required_report_due_date.rb
@@ -4,11 +4,23 @@ class RequiredReportDueDate < ApplicationRecord
   belongs_to :required_report
 
   # Generates and returns attributes for parent class: an array of hashes with 'due_date' key.
+  # Empty array is returned if frequency or start_date is blank.
+  #
   # Ex:
   #     [ { due_date: 2020-01-01 }, { due_date: 2020-02-01 }, ... ]
   def generate_due_date_attributes(frequency, frequency_integer, start_date, end_date)
+    return [] if frequency.blank? || start_date.blank?
+
+    # Convert string parameters to proper types.
+    frequency_integer = frequency_integer.to_i
+    start_date = Date.parse(start_date)
+    end_date = Date.parse(end_date) rescue nil
+
     frequency_calculation = FrequencyCalculation.new
-    due_dates = frequency_calculation.calculate(frequency, frequency_integer, start_date, end_date)
+    due_dates = frequency_calculation.calculate(frequency,
+                                                frequency_integer,
+                                                start_date,
+                                                end_date)
     due_dates.map { |d| { due_date: d } }
   end
 end


### PR DESCRIPTION
This PR includes changes to the `RequiredReportsController` and `RequiredReportDueDate` model.

### Changes
- Type conversion has been moved from the `create` method in the controller to the `generate_due_date_attributes` method in the model.
- Handling for blank `frequency` and `start_date` values is implemented.