### PR TITLE
Bugfix/GPP-344: New Required Report Form end_date should not be before start_date

### DIFF
--- a/app/assets/javascripts/required_reports.js
+++ b/app/assets/javascripts/required_reports.js
@@ -20,21 +20,18 @@ $(document).ready(function () {
         });
 
     $('#new_required_report').submit(function (e) {
-        var local_law_value_length = $('#required_report_local_law').val().length,
+        let local_law_value_length = $('#required_report_local_law').val().length,
             charter_and_code_value_length = $('#required_report_charter_and_code').val().length,
             frequency_value = $('#required_report_frequency').val(),
             frequency_value_length = $('#required_report_frequency').val().length,
             frequency_integer_value_length = $('#required_report_frequency_integer').val().length,
             other_frequency_description_value_length = $('#required_report_other_frequency_description').val().length,
-            start_date = $('#required_report_start_date').val().length,
-            errorDiv = $('#new_required_report #alert-error');
+            start_date = $('#required_report_start_date').val(),
+            end_date = $('#required_report_end_date').val();
 
         // Validate one of local_law or charter_and_code is provided
         if (local_law_value_length === 0 && charter_and_code_value_length === 0) {
-            errorDiv.text('One of Local Law or Charter and Code is required.');
-            errorDiv.show();
-            errorDiv.focus();
-
+            showError('One of Local Law or Charter and Code is required.');
             return false;
         }
 
@@ -43,22 +40,30 @@ $(document).ready(function () {
             // One of frequency or frequency_integer (if frequency is not Once) or start date is empty
             if (frequency_value_length === 0
                 || (frequency_value !== 'Once' && frequency_integer_value_length === 0)
-                || start_date === 0) {
-                errorDiv.text('Frequency, Frequency Integer and Start Date or Other frequency description is required.');
-                errorDiv.show();
-                errorDiv.focus();
-
+                || start_date.length === 0) {
+                showError('Frequency, Frequency Integer and Start Date or Other frequency description is required.');
                 return false;
             }
         } else { // other_frequency_description is not empty
             // One of frequency or frequency_integer is not empty
             if (frequency_value_length > 0 || frequency_integer_value_length > 0) {
-                errorDiv.text('Frequency and Frequency Integer or Other frequency description is required.');
-                errorDiv.show();
-                errorDiv.focus();
-
+                showError('Frequency and Frequency Integer or Other frequency description is required.');
                 return false;
             }
         }
-    })
+
+        // Validate end_date is before start_date if both values are provided
+        if ((start_date && end_date) && (start_date > end_date)) {
+            showError('End date should not be before the start date.');
+            return false;
+        }
+    });
+
+    // Display an error message to the user
+    function showError(message) {
+        let errorDiv = $('#new_required_report #alert-error');
+        errorDiv.text(message);
+        errorDiv.show();
+        errorDiv.focus();
+    }
 });


### PR DESCRIPTION
This PR adds validation to the new required reports form to ensure that if both `start_date` and `end_date` values are provided, the `end_date` must be after the `start_date`.