### PR TITLE
Feature/GPP-349: Remove date submitted value on Request Changes

### DIFF
--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -4,18 +4,7 @@ module Hyrax
 
     def update
       if workflow_action_form.save
-        work = workflow_action_form.work
-        date_published = Date.parse(work.date_published)
-        required_report_name = work.required_report_name
-
-        if (workflow_action_form.name == 'approve') && (required_report_name != 'Not Required')
-          required_report = RequiredReport.where(agency_name: work.agency, name: required_report_name).first
-
-          # Update last_published_date if empty or current work's date is after report's last_published_date
-          if required_report.last_published_date.nil? || (date_published > required_report.last_published_date)
-            required_report.update_attributes(last_published_date: date_published)
-          end
-        end
+        update_required_report(workflow_action_form.work, workflow_action_form.name)
 
         after_update_response
       else
@@ -28,27 +17,55 @@ module Hyrax
 
     private
 
-      def curation_concern
-        @curation_concern ||= ActiveFedora::Base.find(params[:id])
-      end
+    def curation_concern
+      @curation_concern ||= ActiveFedora::Base.find(params[:id])
+    end
 
-      def workflow_action_form
-        @workflow_action_form ||= Hyrax::Forms::WorkflowActionForm.new(
-          current_ability: current_ability,
-          work: curation_concern,
-          attributes: workflow_action_params
-        )
-      end
+    def workflow_action_form
+      @workflow_action_form ||= Hyrax::Forms::WorkflowActionForm.new(
+        current_ability: current_ability,
+        work: curation_concern,
+        attributes: workflow_action_params
+      )
+    end
 
-      def workflow_action_params
-        params.require(:workflow_action).permit(:name, :comment)
-      end
+    def workflow_action_params
+      params.require(:workflow_action).permit(:name, :comment)
+    end
 
-      def after_update_response
-        respond_to do |wants|
-          wants.html { redirect_to [main_app, curation_concern], notice: "The #{curation_concern.human_readable_type} has been updated." }
-          wants.json { render 'hyrax/base/show', status: :ok, location: polymorphic_path([main_app, curation_concern]) }
+    def after_update_response
+      respond_to do |wants|
+        wants.html { redirect_to [main_app, curation_concern], notice: "The #{curation_concern.human_readable_type} has been updated." }
+        wants.json { render 'hyrax/base/show', status: :ok, location: polymorphic_path([main_app, curation_concern]) }
+      end
+    end
+
+    # Update required_report and required_report_due_date values given a work and workflow action
+    def update_required_report(work, workflow_action_name)
+      required_report_name = work.required_report_name
+      return if required_report_name == 'Not Required'
+
+      date_published = Date.parse(work.date_published)
+
+      required_report = RequiredReport.where(agency_name: work.agency, name: required_report_name).first
+
+      case workflow_action_name
+      when 'comment_only'
+        return
+      when 'approve'
+        # Set last_published_date if work is approved and date_published is after current value of last_published_date
+        if required_report.last_published_date.nil? || (date_published > required_report.last_published_date)
+          required_report.update_attributes(last_published_date: date_published)
         end
+      when 'request_changes'
+        # Set date_submitted to nil on request_changes
+        required_report_due_date = RequiredReportDueDate.where(submission_id: work.id).first
+        required_report_due_date.update_attributes(date_submitted: nil)
+      when 'request_review'
+        # Set date_submitted to current date and time on request_review
+        required_report_due_date = RequiredReportDueDate.where(submission_id: work.id).first
+        required_report_due_date.update_attributes(date_submitted: Time.current)
       end
+    end
   end
 end

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -45,7 +45,7 @@
     <%# TODO: If we start using ActionCable, we could listen for object updates and
               alert the user that the object has changed by someone else %>
     <%= f.input Hyrax::Actors::OptimisticLockValidator.version_field, as: :hidden if f.object.persisted? %>
-    <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+    <%= f.submit 'Submit', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
   </div>
 
   <%# Provide immediate feedback after the form is submitted while the subsequent page is loading %>


### PR DESCRIPTION
This PR adds the `update_required_report` method in `WorkflowActionsController` to update `required_reports` and `required_report_due_dates` values accordingly based on a workflow action.

### Changes:
- `date_submitted` in `required_report_due_dates` is removed when a library reviewer Request Changes for a work.
- `date_submitted` in `required_report_due_dates` is populated when an agency submitter Request Review for a work.
- "Save" button on submission form is renamed to "Submit".