### PR TITLE
Feature/GPP-348: Track Deleted Reports

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -152,7 +152,7 @@ module Hyrax
       # Store deleted work's metadata in deleted_publications
       if metadata.present?
         DeletedPublication.create(user_guid: current_user.guid,
-                                  timestamp: Time.now.utc,
+                                  timestamp: Time.current,
                                   metadata: metadata)
       end
 

--- a/app/models/deleted_publication.rb
+++ b/app/models/deleted_publication.rb
@@ -1,0 +1,2 @@
+class DeletedPublication < ApplicationRecord
+end

--- a/db/migrate/20200108193343_create_deleted_publications.rb
+++ b/db/migrate/20200108193343_create_deleted_publications.rb
@@ -1,0 +1,11 @@
+class CreateDeletedPublications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :deleted_publications do |t|
+      t.string :user_guid
+      t.datetime :timestamp
+      t.jsonb :metadata
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200108193343_create_deleted_publications.rb
+++ b/db/migrate/20200108193343_create_deleted_publications.rb
@@ -1,9 +1,9 @@
 class CreateDeletedPublications < ActiveRecord::Migration[5.1]
   def change
     create_table :deleted_publications do |t|
-      t.string :user_guid
-      t.datetime :timestamp
-      t.jsonb :metadata
+      t.string :user_guid, null: false
+      t.datetime :timestamp, null: false
+      t.jsonb :metadata, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191127105815) do
+ActiveRecord::Schema.define(version: 20200108193343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,14 @@ ActiveRecord::Schema.define(version: 20191127105815) do
     t.index ["parent_id"], name: "index_curation_concerns_operations_on_parent_id"
     t.index ["rgt"], name: "index_curation_concerns_operations_on_rgt"
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
+  end
+
+  create_table "deleted_publications", force: :cascade do |t|
+    t.string "user_guid"
+    t.datetime "timestamp"
+    t.jsonb "metadata"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "featured_works", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,9 +100,9 @@ ActiveRecord::Schema.define(version: 20200108193343) do
   end
 
   create_table "deleted_publications", force: :cascade do |t|
-    t.string "user_guid"
-    t.datetime "timestamp"
-    t.jsonb "metadata"
+    t.string "user_guid", null: false
+    t.datetime "timestamp", null: false
+    t.jsonb "metadata", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/deleted_publication_spec.rb
+++ b/spec/models/deleted_publication_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DeletedPublication, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR creates a table called `deleted_publications` to store the metadata of publications when they are deleted.

Notes:
- Only store metadata of works that are published. Using `curation_concern.suppressed?` to check.
- Stored work metadata before the deletion but created the table row after the work was deleted to ensure the deletion was successful. Is this ok or should we do everything all at once before deletion?