### PR TITLE
Feature/GPP-351: T1539: Clear browser data on user logout

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@ class SessionsController < Devise::SessionsController
     saml_uid = session['saml_uid']
     super do
       session['saml_uid'] = saml_uid
+      response.headers['Clear-Site-Data'] = '"*"'
     end
   end
 


### PR DESCRIPTION
This PR adds the `Clear-Site-Data` response header on logout. The wildcard derivative is used to clear all types of data.