### PR TITLE
Feature/GPP-357: T429: Limit the number of concurrent sessions for each account

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,11 +1,16 @@
 class SessionsController < Devise::SessionsController
+  skip_before_action :check_concurrent_session
+
   auto_session_timeout_actions
   SAML_SETTINGS = Devise.omniauth_configs[:saml].strategy
 
   def destroy
     # Preserve the saml_uid in the session
     saml_uid = session['saml_uid']
+    duplicate = session[:duplicate]
+    user = current_user
     super do
+      user.update_attributes(unique_session_id: nil) unless duplicate
       session['saml_uid'] = saml_uid
       response.headers['Clear-Site-Data'] = '"*"'
     end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,7 @@
 # Controller which implements Omniauth callbacks.
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :check_concurrent_session
+
   include NYCID
   def saml
     saml_attrs = request.env['omniauth.auth'].extra.response_object.attributes

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -31,7 +31,7 @@
     <% end %>
   <% else %>
     <li class="nav-item">
-      <%= link_to t("hyrax.toolbar.profile.login"), main_app.new_user_session_path, role: 'button' %>
+      <%= link_to t("hyrax.toolbar.profile.login"), main_app.user_saml_omniauth_authorize_path %>
     </li>
   <% end %>
 

--- a/config/devise_saml.yml
+++ b/config/devise_saml.yml
@@ -11,9 +11,9 @@ default: &default
     want_assertions_signed: true
     want_assertions_encrypted: false
     want_messages_signed: false
-    metadata_signed: false
-    signature_method: "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
-    digest_method: "http://www.w3.org/2000/09/xmldsig#sha1"
+    metadata_signed: true
+    signature_method: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+    digest_method: "http://www.w3.org/2001/04/xmlenc#sha256"
 
 
 development:

--- a/config/initializers/controller_override.rb
+++ b/config/initializers/controller_override.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# OVERRIDE: This overrides deny_access_for_anonymous_user on Controller and renders unauthorized.
+#
+# Base file: https://github.com/samvera/hyrax/blob/2.5.1/app/controllers/concerns/hyrax/controller.rb
+Hyrax::Controller.class_eval do
+  def deny_access_for_anonymous_user(exception, json_message)
+    session['user_return_to'.freeze] = request.url
+    respond_to do |wants|
+      wants.html { render 'hyrax/base/unauthorized', status: :unauthorized }
+      wants.json { render_json_response(response_type: :unauthorized, message: json_message) }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,6 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   devise_scope :user do
-    get 'sign_in', to: 'omniauth#new', as: :new_user_session
-    post 'sign_in', to: 'omniauth_callbacks#saml', as: :new_session
     get 'sign_out', to: 'sessions#destroy', as: :destroy_user_session
     get 'active' => 'sessions#active'
     get 'timeout' => 'sessions#timeout'

--- a/db/migrate/20200130152004_add_unique_session_id_to_users.rb
+++ b/db/migrate/20200130152004_add_unique_session_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddUniqueSessionIdToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :unique_session_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200108193343) do
+ActiveRecord::Schema.define(version: 20200130152004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -598,6 +598,7 @@ ActiveRecord::Schema.define(version: 20200108193343) do
     t.boolean "active", default: false
     t.boolean "nyc_employee", default: false
     t.boolean "has_nyc_account", default: false
+    t.string "unique_session_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
This PR implements a limit the number of concurrent sessions to **1** for each account. 

A migration was generated to add the field `unique_session_id` to `users`. The value of `unique_session_id` is updated every time a user is logged in. 

A `check_concurrent_session` method is created in `ApplicationController` and set as `before_action` to check for if user's current session id is different than `unique_session_id` in the database. If it is different, then the user is redirected to the logout endpoint.

In `session#destroy`, `unique_session_id` is set to `nil` if user logs out manually or is timed out - not if user is logged out from having multiple sessions.

Additional saml configuration changes were made:
- Use sha256 instead of sha1.
- Remove `sign_in` routes as `user_saml_omniauth_authorize_path` can be used directly.