### PR TITLE
Feature/GPP-307: Added heading for search results on search page

### DIFF
--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,24 @@
+<h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
+
+<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+
+<% content_for(:head) do -%>
+  <%= render_opensearch_response_metadata %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
+  <%= json_api_link_tag %>
+<% end %>
+
+<h2><%= t('blacklight.search.search_results') %></h2>
+
+<%= render 'search_header' %>
+
+<%- if @response.empty? %>
+  <%= render "zero_results" %>
+<%- elsif render_grouped_response? %>
+  <%= render_grouped_document_index %>
+<%- else %>
+  <%= render_document_index %>
+<%- end %>
+
+<%= render 'results_pagination' %>


### PR DESCRIPTION
This PR adds the heading "Search Results" to the search page. Removed the `sr-only` class from original code to make it visible for all and shifted it's position to the top of the results before the previous and next buttons.