### PR TITLE
Disabled Turbolinks for Skip to Content Anchor

### DIFF
--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -16,7 +16,7 @@
     <% end %>
 
     <div class="skip-to-content">
-      <%= link_to "Skip to Content", "#skip-to-content" %>
+      <%= link_to "Skip to Content", "#skip-to-content" , data: { turbolinks: false } %>
     </div>
     <%= render '/nycid_header' %>
     <%= render '/masthead' %>
@@ -37,7 +37,7 @@
         </div>
       <% end %>
 
-        <a name="skip-to-content" id="skip-to-content"></a>
+        <a name="skip-to-content" id="skip-to-content" tabindex="0"></a>
         <%= content_for?(:content) ? yield(:content) : yield %>
 
     </div><!-- /#content-wrapper -->

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -16,7 +16,7 @@
     <% end %>
 
     <div class="skip-to-content">
-      <%= link_to "Skip to Content", "#skip-to-content" %>
+      <%= link_to "Skip to Content", "#skip-to-content", data: { turbolinks: false } %>
     </div>
     <%= render '/nycid_header' %>
     <%= render '/masthead' %>
@@ -36,7 +36,7 @@
           </div>
         <% end %>
 
-          <a name="skip-to-content" id="skip-to-content"></a>
+          <a name="skip-to-content" id="skip-to-content" tabindex="0"></a>
           <%= content_for?(:content) ? yield(:content) : yield %>
 
       </div>


### PR DESCRIPTION
This PR disables the turbolink for the "Skip to Content" anchor so that focus is maintained on the main content of the page without reloading.