### PR TITLE
Feature/GPP-311: Wave Report Fixes

### DIFF
--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -245,3 +245,7 @@ body.gpp-dashboard {
     word-wrap: break-word;
   }
 }
+
+.gpp-nav-link {
+  color: black !important;
+}

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+module Blacklight::FacetsHelperBehavior
+  include Blacklight::Facet
+
+  ##
+  # Check if any of the given fields have values
+  #
+  # @param [Array<String>] fields
+  # @param [Hash] options
+  # @return [Boolean]
+  def has_facet_values? fields = facet_field_names, options = {}
+    facets_from_request(fields).any? { |display_facet| !display_facet.items.empty? && should_render_facet?(display_facet) }
+  end
+
+  ##
+  # Render a collection of facet fields.
+  # @see #render_facet_limit
+  #
+  # @param [Array<String>] fields
+  # @param [Hash] options
+  # @return String
+  def render_facet_partials fields = facet_field_names, options = {}
+    safe_join(facets_from_request(fields).map do |display_facet|
+      render_facet_limit(display_facet, options)
+    end.compact, "\n")
+  end
+
+  ##
+  # Renders a single section for facet limit with a specified
+  # solr field used for faceting. Can be over-ridden for custom
+  # display on a per-facet basis.
+  #
+  # @param [Blacklight::Solr::Response::Facets::FacetField] display_facet
+  # @param [Hash] options parameters to use for rendering the facet limit partial
+  # @option options [String] :partial partial to render
+  # @option options [String] :layout partial layout to render
+  # @option options [Hash] :locals locals to pass to the partial
+  # @return [String]
+  def render_facet_limit(display_facet, options = {})
+    return unless should_render_facet?(display_facet)
+    options = options.dup
+    options[:partial] ||= facet_partial_name(display_facet)
+    options[:layout] ||= "facet_layout" unless options.key?(:layout)
+    options[:locals] ||= {}
+    options[:locals][:field_name] ||= display_facet.name
+    options[:locals][:solr_field] ||= display_facet.name # deprecated
+    options[:locals][:facet_field] ||= facet_configuration_for_field(display_facet.name)
+    options[:locals][:display_facet] ||= display_facet
+
+    render(options)
+  end
+
+  ##
+  # Renders the list of values
+  # removes any elements where render_facet_item returns a nil value. This enables an application
+  # to filter undesireable facet items so they don't appear in the UI
+  def render_facet_limit_list(paginator, facet_field, wrapping_element=:li)
+    safe_join(paginator.items.map { |item| render_facet_item(facet_field, item) }.compact.map { |item| content_tag(wrapping_element,item)})
+  end
+
+  ##
+  # Renders a single facet item
+  def render_facet_item(facet_field, item)
+    if facet_in_params?(facet_field, item.value )
+      render_selected_facet_value(facet_field, item)
+    else
+      render_facet_value(facet_field, item)
+    end
+  end
+
+  ##
+  # Determine if Blacklight should render the display_facet or not
+  #
+  # By default, only render facets with items.
+  #
+  # @param [Blacklight::Solr::Response::Facets::FacetField] display_facet
+  # @return [Boolean]
+  def should_render_facet? display_facet
+    # display when show is nil or true
+    facet_config = facet_configuration_for_field(display_facet.name)
+    display = should_render_field?(facet_config, display_facet)
+    display && display_facet.items.present?
+  end
+
+  ##
+  # Determine whether a facet should be rendered as collapsed or not.
+  #   - if the facet is 'active', don't collapse
+  #   - if the facet is configured to collapse (the default), collapse
+  #   - if the facet is configured not to collapse, don't collapse
+  #
+  # @param [Blacklight::Configuration::FacetField] facet_field
+  # @return [Boolean]
+  def should_collapse_facet? facet_field
+    !facet_field_in_params?(facet_field.key) && facet_field.collapse
+  end
+
+  ##
+  # The name of the partial to use to render a facet field.
+  # uses the value of the "partial" field if set in the facet configuration
+  # otherwise uses "facet_pivot" if this facet is a pivot facet
+  # defaults to 'facet_limit'
+  #
+  # @return [String]
+  def facet_partial_name(display_facet = nil)
+    config = facet_configuration_for_field(display_facet.name)
+    name = config.try(:partial)
+    name ||= "facet_pivot" if config.pivot
+    name ||= "facet_limit"
+  end
+
+  ##
+  # Standard display of a facet value in a list. Used in both _facets sidebar
+  # partial and catalog/facet expanded list. Will output facet value name as
+  # a link to add that to your restrictions, with count in parens.
+  #
+  # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
+  # @param [Blacklight::Solr::Response::Facets::FacetItem] item
+  # @param [Hash] options
+  # @option options [Boolean] :suppress_link display the facet, but don't link to it
+  # @return [String]
+  def render_facet_value(facet_field, item, options ={})
+    path = path_for_facet(facet_field, item)
+    content_tag(:span, :class => "facet-label") do
+      link_to_unless(options[:suppress_link], facet_display_value(facet_field, item), path, :class=>"facet_select")
+    end + render_facet_count(item.hits)
+  end
+
+  ##
+  # Where should this facet link to?
+  # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
+  # @param [String] item
+  # @return [String]
+  def path_for_facet(facet_field, item)
+    facet_config = facet_configuration_for_field(facet_field)
+    if facet_config.url_method
+      send(facet_config.url_method, facet_field, item)
+    else
+      search_action_path(search_state.add_facet_params_and_redirect(facet_field, item))
+    end
+  end
+
+  ##
+  # Standard display of a SELECTED facet value (e.g. without a link and with a remove button)
+  # @see #render_facet_value
+  # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
+  # @param [String] item
+  def render_selected_facet_value(facet_field, item)
+    remove_href = search_action_path(search_state.remove_facet_params(facet_field, item))
+    content_tag(:span, class: "facet-label") do
+      content_tag(:span, facet_display_value(facet_field, item), class: "selected") +
+          # remove link
+          link_to(remove_href, class: "remove") do
+            content_tag(:span, '', class: "glyphicon glyphicon-remove") +
+                content_tag(:span, '[remove]', class: 'sr-only', style: "color: black;")
+          end
+    end + render_facet_count(item.hits, :classes => ["selected"])
+  end
+
+  ##
+  # Renders a count value for facet limits. Can be over-ridden locally
+  # to change style. And can be called by plugins to get consistent display.
+  #
+  # @param [Integer] num number of facet results
+  # @param [Hash] options
+  # @option options [Array<String>]  an array of classes to add to count span.
+  # @return [String]
+  def render_facet_count(num, options = {})
+    classes = (options[:classes] || []) << "facet-count"
+    content_tag("span", t('blacklight.search.facets.count', :number => number_with_delimiter(num)), :class => classes)
+  end
+
+  ##
+  # Are any facet restrictions for a field in the query parameters?
+  #
+  # @param [String] field
+  # @return [Boolean]
+  def facet_field_in_params? field
+    !facet_params(field).blank?
+  end
+
+  ##
+  # Check if the query parameters have the given facet field with the
+  # given value.
+  #
+  # @param [Object] field
+  # @param [Object] item facet value
+  # @return [Boolean]
+  def facet_in_params?(field, item)
+    value = facet_value_for_facet_item(item)
+
+    (facet_params(field) || []).include? value
+  end
+
+  ##
+  # Get the values of the facet set in the blacklight query string
+  def facet_params field
+    config = facet_configuration_for_field(field)
+
+    params[:f][config.key] if params[:f]
+  end
+
+  ##
+  # Get the displayable version of a facet's value
+  #
+  # @param [Object] field
+  # @param [String] item value
+  # @return [String]
+  def facet_display_value field, item
+    facet_config = facet_configuration_for_field(field)
+
+    value = if item.respond_to? :label
+              item.label
+            else
+              facet_value_for_facet_item(item)
+            end
+
+    if facet_config.helper_method
+      send facet_config.helper_method, value
+    elsif facet_config.query && facet_config.query[value]
+      facet_config.query[value][:label]
+    elsif facet_config.date
+      localization_options = facet_config.date == true ? {} : facet_config.date
+
+      l(value.to_datetime, localization_options)
+    else
+      value
+    end
+  end
+
+  def facet_field_id facet_field
+    "facet-#{facet_field.key.parameterize}"
+  end
+
+  private
+
+  def facet_value_for_facet_item item
+    if item.respond_to? :value
+      item.value
+    else
+      item
+    end
+  end
+end

--- a/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
+++ b/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
@@ -1,0 +1,57 @@
+module BlacklightAdvancedSearch
+  # implementation for AdvancedHelper
+  module AdvancedHelperBehavior
+    # Fill in default from existing search, if present
+    # -- if you are using same search fields for basic
+    # search and advanced, will even fill in properly if existing
+    # search used basic search on same field present in advanced.
+    def label_tag_default_for(key)
+      if !params[key].blank?
+        return params[key]
+      elsif params["search_field"] == key
+        return params["q"]
+      else
+        return nil
+      end
+    end
+
+    # Is facet value in adv facet search results?
+    def facet_value_checked?(field, value)
+      BlacklightAdvancedSearch::QueryParser.new(params, blacklight_config).filters_include_value?(field, value)
+    end
+
+    def select_menu_for_field_operator
+      options = {
+          t('blacklight_advanced_search.all') => 'AND',
+          t('blacklight_advanced_search.any') => 'OR'
+      }.sort
+
+      select_tag(:op, options_for_select(options, params[:op]), class: 'input-small', aria: { label: 'filter-options' } )
+    end
+
+    # Current params without fields that will be over-written by adv. search,
+    # or other fields we don't want.
+    def advanced_search_context
+      my_params = search_state.params_for_search.except :page, :f_inclusive, :q, :search_field, :op, :index, :sort
+
+      my_params.except!(*search_fields_for_advanced_search.map { |_key, field_def| field_def[:key] })
+    end
+
+    def search_fields_for_advanced_search
+      @search_fields_for_advanced_search ||= begin
+                                               blacklight_config.search_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
+                                             end
+    end
+
+    def facet_field_names_for_advanced_search
+      @facet_field_names_for_advanced_search ||= begin
+                                                   blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }.values.map(&:field)
+                                                 end
+    end
+
+    # Use configured facet partial name for facet or fallback on 'catalog/facet_limit'
+    def advanced_search_facet_partial_name(display_facet)
+      facet_configuration_for_field(display_facet.name).try(:partial) || "catalog/facet_limit"
+    end
+  end
+end

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -3,14 +3,14 @@
     <div class="row">
       <ul class="nav navbar-nav col-sm-5">
         <li <%= 'class=active' if current_page?(hyrax.root_path) %>>
-          <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil %></li>
+          <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil, class: 'gpp-nav-link' %></li>
         <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
-          <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+          <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil, class: 'gpp-nav-link' %></li>
         <li <%= 'class=active' if current_page?(main_app.public_list_required_reports_path) %>>
-          <%= link_to t(:'hyrax.controls.public_list_required_reports'), main_app.public_list_required_reports_path, aria: current_page?(main_app.public_list_required_reports_path) ? {current: 'page'} : nil %></li>
+          <%= link_to t(:'hyrax.controls.public_list_required_reports'), main_app.public_list_required_reports_path, aria: current_page?(main_app.public_list_required_reports_path) ? {current: 'page'} : nil, class: 'gpp-nav-link' %></li>
         <% if current_user and (current_user.admin? or current_user.library_reviewers?) %>
           <li <%= 'class=active' if current_page?(main_app.required_reports_path) %>>
-            <%= link_to t(:'hyrax.controls.manage_required_reports'), main_app.required_reports_path, aria: current_page?(main_app.required_reports_path) ? {current: 'page'} : nil %></li>
+            <%= link_to t(:'hyrax.controls.manage_required_reports'), main_app.required_reports_path, aria: current_page?(main_app.required_reports_path) ? {current: 'page'} : nil, class: 'gpp-nav-link' %></li>
         <% end %>
       </ul><!-- /.nav -->
       <div class="searchbar-right navbar-right col-sm-7">

--- a/app/views/hyrax/collections/_show_document_list.html.erb
+++ b/app/views/hyrax/collections/_show_document_list.html.erb
@@ -1,5 +1,5 @@
 <table class="table table-striped">
-  <caption class="sr-only">List of items in this collection</caption>
+  <caption class="sr-only" style="color: black;">List of items in this collection</caption>
   <thead>
   <tr>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -76,6 +76,18 @@
   <div class="row">
     <div class="col-md-8 hyc-description">
       <%= render 'collection_description', presenter: @presenter %>
+
+      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+        <div class="hyc-blacklight hyc-bl-title">
+          <h2>
+            <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
+          </h2>
+        </div>
+        <div class="hyc-blacklight hyc-bl-results">
+          <%= render 'show_parent_collections', presenter: @presenter %>
+        </div>
+      <% end %>
+
     </div>
   </div>
 
@@ -92,17 +104,6 @@
                     new_polymorphic_path([main_app, @presenter.first_work_type], add_works_to_collection: @presenter.id),
                     class: 'btn btn-primary submit-btn' %>
       <% end %>
-    </div>
-  <% end %>
-
-  <!-- Search results label -->
-  <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
-    <div class="hyc-blacklight hyc-bl-title">
-      <h2>
-        <% if has_collection_search_parameters? %>
-            <%= t('hyrax.dashboard.collections.show.search_results') %>
-        <% end %>
-      </h2>
     </div>
   <% end %>
 

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -76,18 +76,6 @@
   <div class="row">
     <div class="col-md-8 hyc-description">
       <%= render 'collection_description', presenter: @presenter %>
-
-      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
-          <div class="hyc-blacklight hyc-bl-title">
-            <h2>
-              <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
-            </h2>
-          </div>
-          <div class="hyc-blacklight hyc-bl-results">
-            <%= render 'show_parent_collections', presenter: @presenter %>
-          </div>
-      <% end %>
-
     </div>
   </div>
 

--- a/app/views/shared/_ajax_modal.html.erb
+++ b/app/views/shared/_ajax_modal.html.erb
@@ -1,0 +1,6 @@
+<div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="ajax-modal" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This PR fixes accessibility errors raised by the WAVE evaluation tool.

Changes:
- Fixed contrast on navigation links
- Fixed broken aria-labelledby references
- Added aria-label to filter dropdown in advanced search
- Removed empty h2 header

You can test each page by using the Chrome browser extension or pasting the URL in the WAVE site:
- https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh
- https://wave.webaim.org