### PR TITLE
Feature/GPP-371: Additional 508 Changes

### DIFF
--- a/app/helpers/hyrax/title_helper.rb
+++ b/app/helpers/hyrax/title_helper.rb
@@ -1,0 +1,23 @@
+module Hyrax::TitleHelper
+  def application_name
+    t('hyrax.product_name', default: super)
+  end
+
+  def construct_page_title(*elements)
+    (elements.flatten.compact + [application_name]).join(' - ')
+  end
+
+  def curation_concern_page_title(curation_concern)
+    if curation_concern.persisted?
+      construct_page_title(curation_concern.to_s, "#{curation_concern.human_readable_type} [#{curation_concern.to_param}]")
+    else
+      construct_page_title("New #{curation_concern.human_readable_type}")
+    end
+  end
+
+  def default_page_title
+    text = controller_name.singularize.titleize
+    text = "#{action_name.titleize} " + text if action_name
+    construct_page_title(text)
+  end
+end

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,0 +1,21 @@
+<% provide :page_title, construct_page_title('More Search Options') %>
+
+<div class="advanced-search-form col-sm-12">
+
+  <h1 class="advanced page-header">
+    <%= t('blacklight_advanced_search.form.title') %>
+    <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-default pull-right advanced-search-start-over" %>
+  </h1>
+
+  <div class="row">
+
+    <div class="col-md-8">
+      <%= render 'advanced_search_form' %>
+    </div>
+    <div class="col-md-4">
+      <%= render "advanced_search_help" %>
+    </div>
+
+  </div>
+
+</div>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,6 +1,6 @@
 <h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
 
-<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+<% provide :page_title, construct_page_title('Search') %>
 
 <% content_for(:head) do -%>
   <%= render_opensearch_response_metadata %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -9,7 +9,7 @@
   <%= json_api_link_tag %>
 <% end %>
 
-<h2><%= t('blacklight.search.search_results') %></h2>
+<h1 tabindex="0"><%= t('blacklight.search.search_results') %></h1>
 
 <%= render 'search_header' %>
 

--- a/app/views/hyrax/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/collections/_sort_and_per_page.html.erb
@@ -1,5 +1,6 @@
 <% if show_sort_and_per_page? && active_sort_fields.many? %>
   <%= form_tag collection_path(collection), method: :get, class: 'per_page form-horizontal' do %>
+    <h2>Sort Publications</h2>
     <fieldset class="pull-left">
       <legend class="sr-only"><%= t('hyrax.sort_label') %></legend>
       <%= label_tag(:sort, '<span>Sort by:</span>'.html_safe) %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -124,6 +124,8 @@
       </div>
 
       <div class="hyc-blacklight hyc-bl-results">
+        <br>
+        <h2>Available Publications</h2>
         <%= render_document_index @member_docs %>
       </div>
 

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -74,7 +74,7 @@
   </div>
 
   <div class="row">
-    <div class="col-md-8 hyc-description">
+    <div class="col-md-8">
       <%= render 'collection_description', presenter: @presenter %>
 
       <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,4 +1,4 @@
-<% provide :page_title, construct_page_title(@presenter.title) %>
+<% provide :page_title, construct_page_title('Home') %>
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
   <div class="row hyc-header">
     <div class="col-md-12">

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,27 +1,4 @@
 <% provide :page_title, construct_page_title(@presenter.title) %>
-<div class="hyc-container">
-  <p>Welcome to the Government Publications Portal. The Government Publications Portal is a permanent searchable
-    digital repository for all of New York City’s recent agency publications. The portal is maintained by the
-    Municipal Library at the New York City Department of Records and Information Services (DORIS). The portal is
-    part of New York City government’s ongoing mission to make government information publicly and easily
-    accessible. The <a
-    href="http://library.amlegal.com/nxt/gateway.dll/New%20York/charter/newyorkcitycharter/chapter49officersandemployees?f=templates$fn=default.htm$3.0$vid=amlegal:newyork_ny$anc=JD_1133"
-    target="_blank" rel="noopener noreferrer">New York City Charter, Section 1133</a>, requires agencies to submit
-    digital copies of all publications to the Library for permanent
-    access and storage. Beginning July 1, 2019, DORIS will maintain a list of all required reports on its website
-    for public perusal. Effective January 1, 2020, more information will be available including not only access
-    to the report but citation to the law requiring the publication, date or reporting period covered. Should
-    the agencies concerned not submit the report within the required time limit, DORIS will issue a request for the
-    report to the agency. Such requests will be published on the government publications website in place of the
-    report until such report is published.</p>
-  <p>For older agency publications on paper, please consult our <a href="https://nycrecords.bywatersolutions.com/"
-                                                                   target="_blank" rel="noopener noreferrer">electronic
-    catalog</a>.</p>
-  <p>To find publications, search by keyword, such as agency name, subject, title, report type, or date. Once you
-    have search results, you can sort them further using filters, including by relevance, by date, or with just one
-    letter of the alphabet.</p>
-</div>
-<br>
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
   <div class="row hyc-header">
     <div class="col-md-12">
@@ -71,6 +48,29 @@
       </header>
 
     </div>
+  </div>
+
+  <div class="hyc-container">
+    <p>Welcome to the Government Publications Portal. The Government Publications Portal is a permanent searchable
+      digital repository for all of New York City’s recent agency publications. The portal is maintained by the
+      Municipal Library at the New York City Department of Records and Information Services (DORIS). The portal is
+      part of New York City government’s ongoing mission to make government information publicly and easily
+      accessible. The <a
+      href="http://library.amlegal.com/nxt/gateway.dll/New%20York/charter/newyorkcitycharter/chapter49officersandemployees?f=templates$fn=default.htm$3.0$vid=amlegal:newyork_ny$anc=JD_1133"
+      target="_blank" rel="noopener noreferrer">New York City Charter, Section 1133</a>, requires agencies to submit
+      digital copies of all publications to the Library for permanent
+      access and storage. Beginning July 1, 2019, DORIS will maintain a list of all required reports on its website
+      for public perusal. Effective January 1, 2020, more information will be available including not only access
+      to the report but citation to the law requiring the publication, date or reporting period covered. Should
+      the agencies concerned not submit the report within the required time limit, DORIS will issue a request for the
+      report to the agency. Such requests will be published on the government publications website in place of the
+      report until such report is published.</p>
+    <p>For older agency publications on paper, please consult our <a href="https://nycrecords.bywatersolutions.com/"
+                                                                     target="_blank" rel="noopener noreferrer">electronic
+      catalog</a>.</p>
+    <p>To find publications, search by keyword, such as agency name, subject, title, report type, or date. Once you
+      have search results, you can sort them further using filters, including by relevance, by date, or with just one
+      letter of the alphabet.</p>
   </div>
 
   <div class="row">

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,3 +1,4 @@
+<% provide :page_title, construct_page_title('Contact Us') %>
 <h1>
   Contact Us
 </h1>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,0 +1,51 @@
+<% if current_user and (current_user.admin? or current_user.library_reviewers?) %>
+  <div class="btn-group">
+
+    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
+      <span class="sr-only">Press to </span>
+      <%= t('.header') %>
+      <span class="caret" aria-hidden="true"></span>
+    </button>
+
+    <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
+      <% if can?(:edit, file_set.id) %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.edit'), edit_polymorphic_path([main_app, file_set]),
+                      { title: t('.edit_title', file_set: file_set) } %>
+        </li>
+
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.versions'),  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
+                      { title: t('.versions_title') } %>
+        </li>
+      <% end %>
+
+      <% if can?(:destroy, file_set.id) %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.delete'), polymorphic_path([main_app, file_set]),
+                      method: :delete, title: t('.delete_title', file_set: file_set),
+                      data: { confirm: t('.delete_confirm', file_set: file_set, application_name: application_name) } %>
+        </li>
+      <% end %>
+
+      <% if can?(:download, file_set.id) %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.download'),
+                      hyrax.download_path(file_set),
+                      title: t('.download_title', file_set: file_set),
+                      target: "_blank",
+                      id: "file_download",
+                      data: { label: file_set.id } %>
+        </li>
+      <% end %>
+
+    </ul>
+  </div>
+<% else %>
+  <%= link_to t('.download'),
+              hyrax.download_path(file_set),
+              title: t('.download_title', file_set: file_set),
+              target: "_blank",
+              id: "file_download",
+              data: { label: file_set.id } %>
+<% end %>

--- a/app/views/kaminari/blacklight_compact/_paginator.html.erb
+++ b/app/views/kaminari/blacklight_compact/_paginator.html.erb
@@ -1,0 +1,37 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+
+   Paginator now using the Bootstrap paginator class
+
+   page_entries_info is passed into the paginate call, e.g. :
+
+   > paginate collection, :page_entries_info => page_entries_info(collection), :theme => :blacklight_compact
+
+   As of Kaminari 0.15, this paginator doesn't have access to the original collection/scope, so it can't render the page entries info directly.
+-%>
+<% if total_pages > 1 -%>
+  <%# #render checks if total_pages > 1, so we can't put our fallback
+  in here .. -%>
+  <%= paginator.render do -%>
+    <div class="page_links">
+      <%= prev_page_tag %>&nbsp;&nbsp;|&nbsp;&nbsp;
+      <span class="page_entries" tabindex="0">
+        Displaying
+        <%= page_entries_info %>
+        Results
+      </span>&nbsp;&nbsp;|&nbsp;&nbsp;
+      <%= next_page_tag %>
+    </div>
+  <% end -%>
+<% else -%>
+  <div class="page_links">
+      <span class="page_entries" tabindex="0">
+        <%= page_entries_info %>
+      </span>
+  </div>
+<% end -%>

--- a/app/views/required_reports/index.html.erb
+++ b/app/views/required_reports/index.html.erb
@@ -1,3 +1,4 @@
+<% provide :page_title, construct_page_title('Manage Required Reports') %>
 <p id="notice"><%= notice %></p>
 
 <h1>Required Reports</h1>

--- a/app/views/required_reports/public_list.html.erb
+++ b/app/views/required_reports/public_list.html.erb
@@ -25,7 +25,7 @@
         <td><%= required_report.local_law %></td>
         <td><%= required_report.charter_and_code %></td>
         <td><%= required_report.last_published_date %></td>
-        <td><%= link_to 'Search', @search_url[0] + url_encode(required_report.agency_name) + @search_url[1] + url_encode(required_report.name) + @search_url[2] %></td>
+        <td><%= link_to 'Search', @search_url[0] + url_encode(required_report.agency_name) + @search_url[1] + url_encode(required_report.name) + @search_url[2], aria: { label: 'Search all, ' + required_report.name } %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/required_reports/public_list.html.erb
+++ b/app/views/required_reports/public_list.html.erb
@@ -1,3 +1,4 @@
+<% provide :page_title, construct_page_title('Required Reports') %>
 <h1>Required Reports</h1>
 
 <div class="table-responsive">


### PR DESCRIPTION
This PR adds additional changes for 508 accessibility based on Walei's feedback.

1. (Feedback on ) Add an h3 heading before the table. Suggestion to make the label “Displaying X of Y records.”Dev note: We can use the text from the built in blacklight pagination widget. (1 - 10 of 1,983)
**Changes Made: Added tabindex to the "Search Results" heading and the label below it so that can be focused by the keyboard. The label below the heading now has the format, "Displaying X - Y of Z Results"**

2. (Feedback on ) 2 alerts generated from WAVE report:

- One is for justified text.

- The other is for redundant text label
**Changes Made: Removed the `hyc-description` class from collection description so the text is no longer justified (Note that this was for the collection desc added through the UI, not what we wrote ourselves). As for the "redundant text label", I think Walei was referring to a redundant link which was caused by the pagination widget. The "Next" button and the 2nd page button have the same link so I believe this would be a false positive.**

3. Move the Government Publications h1 heading so that it is before the text that explains what this website is.
**Changes Made: Moved the container with the GPP description to be below the first heading.**

4. Make an h2 heading before the text “Sort the listing of items by” with the label “Search Filter”.
**Changes Made: Added a h2 with "Sort Publications" before the sort options.**

5. Before the table of records is another table with the text, "List of items in this collection". This sounds like the title of the table. The text should be before the table as a paragraph or a heading
Dev Note: Screen reader may be mistaking the table’s caption as something else due to the sr-only class. Would adding an additional heading called “Available Publications” be helpful to differentiate?
**Changes Made: I think this may also be a false positive but I added a h2 with "Available Publications" before the table incase. We should discuss if we think changes 4 and 5 were necessary or maybe a better way to handle it.**

6. Remove slashes from page titles. Follow the format <PAGE NAME> - Government Publications Portal.
**Changes Made: In `title_hepler.rb` I changed the slashes to a dash to separate page name and application name. For any pages that didn't have an accurate page name that was auto generated by Rails, I manually set the page name using `<% provide :page_title, construct_page_title('PAGE_NAME') %>`**

7. On the view publication page, change the dropdown for "Select an action" to be a single download link since there are no other options.
**Changes Made: In `_actions.html.erb` I did a check to only show the actions dropdown if the user is an admin or library_reviewer. Otherwise replace it with just a link to download the file.**

8. All search links on the required report page currently have the same label, "Search". Add a unique aria-label to each link based on the name of the report. Format can be something like "Search all, <REPORT NAME>.
Dev note: Some report names will repeat across multiple agencies such as "Annual Report". Is this okay?
**Changes Made: In `public_list.html.erb` I added an aria label to each search link with the name of the report to help differentiate it from others.**