### PR TITLE
Fix slowness when running uvscan

### DIFF
--- a/lib/mcafee_virus_scan_linux.rb
+++ b/lib/mcafee_virus_scan_linux.rb
@@ -12,7 +12,7 @@ class McafeeVirusScanLinux < Hydra::Works::VirusScanner
   end
 
   def mcafee_scanner
-    scan_command = "#{@uvscan_path} --delete -v #{file}"
+    scan_command = "sudo #{@uvscan_path} --delete --v #{file}"
     system(scan_command)
     file_exists = Dir.glob(file)
     return false unless file_exists.empty?


### PR DESCRIPTION
Run command as root (will require the following entry in `/etc/sudoers`):
```
hyrax	ALL= NOPASSWD: /usr/local/bin/uvscan
```
Recommended to create a specific file for handling users who need to run uvscan (e.g. `/etc/sudoers.d/uvscan`)

This reduces the runtime on Staging from approximately 50 s for a 35 Kb file to 2.89s.

After updating DAT files the following command needs to be run (as root):
```bash
sudo /usr/local/bin/uvscan --decompress
```
This will decompress the DAT files and speed up subsequent scans. 

Corresponding changes are being made to the Ansible playbooks and roles. 