### PR TITLE
Feature/GPP-371: Additional 508 Changes (Part 2)

### DIFF
--- a/app/views/hyrax/collections/_show_document_list.html.erb
+++ b/app/views/hyrax/collections/_show_document_list.html.erb
@@ -1,5 +1,4 @@
 <table class="table table-striped">
-  <caption class="sr-only" style="color: black;">List of items in this collection</caption>
   <thead>
   <tr>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>

--- a/app/views/required_reports/public_list.html.erb
+++ b/app/views/required_reports/public_list.html.erb
@@ -5,6 +5,7 @@
   <table id="required-report-table" class="table table-striped table-bordered">
     <thead>
     <tr>
+      <th class="col-md-2">ID</th>
       <th class="col-md-2">Agency</th>
       <th class="col-md-2">Name</th>
       <th class="col-md-3">Description</th>
@@ -17,8 +18,9 @@
     </thead>
 
     <tbody>
-    <% @required_reports.each do |required_report| %>
+    <% @required_reports.each_with_index do |required_report, index| %>
       <tr>
+        <th aria-label="ID: <%= index + 1 %>. Agency: <%= required_report.agency_name %>. Report Name: <%= required_report.name %>. The value in this cell is "><%= index + 1 %></th>
         <td><%= required_report.agency_name %></td>
         <td><%= required_report.name %></td>
         <td><%= required_report.description %></td>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -98,7 +98,7 @@ en:
         title: ''
       # Hints for NYC Government Publication Work
       nyc_government_publication:
-        title: On the front page, the first page or in the Executive Summary (if any) of the docucment, what is it called? 10-150 characters.
+        title: On the front page, the first page or in the Executive Summary (if any) of the document, what is it called? 10-150 characters.
         agency: What agency is the primary creator of this document?
         required_report_name: Please select an Agency before selecting Required Report Name. If your required report is not on this list, please contact <a href="mailto:municipal-library-admins@records.nyc.gov">municipal-library-admins@records.nyc.gov</a>.
         additional_creators: What other agencies, consultants, or authors, if any, contributed to the creation of this document?


### PR DESCRIPTION
Changes made:
- Fixed "document" typo in submissions form.
- As per Walei's suggestion, removed caption tag in collection table to reduce confusion for screen reader.
- Added a row heading to each row of the required reports table. When navigating from row to row it will give a helpful description of the data found in the row.

Notes:
- Used index of the required reports list instead of ID because reports added in the future will have  much higher ID numbers which would not make sense in the table since we order by agency.
- To test using voiceover, navigate to the table and use CONTROL + OPTION + UP/DOWN ARROW to move between rows. Use CONTROL + OPTION +LEFT/RIGHT ARROW to move between columns.