### PR TITLE
Bugfix/GPP-380: Derivatives Not Created When SOLR_URL Uses SSL

### DIFF
--- a/config/initializers/full_text_override.rb
+++ b/config/initializers/full_text_override.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# OVERRIDE: This overrides http_request on FullText and fixes bug for ssl.
+#
+# Base file: https://github.com/samvera/hydra-derivatives/blob/v3.5.0/lib/hydra/derivatives/processors/full_text.rb
+Hydra::Derivatives::Processors::FullText.class_eval do
+  def http_request
+    Net::HTTP.start(uri.host, uri.port, use_ssl: check_for_ssl) do |http|
+      req = Net::HTTP::Post.new(uri.request_uri, request_headers)
+      req.basic_auth uri.user, uri.password unless uri.password.nil?
+      req.body = file_content
+      http.request req
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the bug with the hydra-derivates gem (v3.5.0) where the `http_request` method throws **NoMethodError for `use_ssl=' for #<Net::HTTP:Post POST>** when url for solr is https (SSL).