### PR TITLE
Feature/GPP-383: Fix Color Contrast (Part 2)

### DIFF
--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -252,6 +252,7 @@ body.gpp-dashboard {
 
 .underline-link {
   text-decoration: underline;
+  color: #036 !important;
 }
 
 a.gpp-nav-link:hover, a.gpp-nav-link:focus {
@@ -261,16 +262,19 @@ a.gpp-nav-link:hover, a.gpp-nav-link:focus {
 // Adds underline to links on the view submissions page
 li.attribute a {
   text-decoration: underline;
+  color: #036 !important;
 }
 
 // Adds underline to links on the search results page
 dl.dl-horizontal dd a {
   text-decoration: underline;
+  color: #036 !important;
 }
 
 // Adds underline to links in the user activity table on file details page
 table#activity a {
   text-decoration: underline;
+  color: #036 !important;
 }
 
 // Changes color of focus outline globally

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default navbar-static-top" role="navigation" aria-label="Secondary Navigation" tabindex="0">
+<nav class="navbar navbar-default navbar-static-top" role="navigation" aria-label="Secondary Navigation">
   <div class="container-fluid">
     <div class="row">
       <ul class="nav navbar-nav col-sm-5">

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation" tabindex="0" aria-label="Main Navigation">
+  <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation" aria-label="Main Navigation">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
       <div class="navbar-header">

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -8,7 +8,7 @@
       Search
     </label>
 
-    <div class="input-group" aria-label="Search Bar" tabindex="0">
+    <div class="input-group" aria-label="Search Bar">
       <%= text_field_tag :q,
                          current_search_parameters,
                          class: "q form-control",

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -9,7 +9,7 @@
   <%= json_api_link_tag %>
 <% end %>
 
-<h1 tabindex="0"><%= t('blacklight.search.search_results') %></h1>
+<h1><%= t('blacklight.search.search_results') %></h1>
 
 <%= render 'search_header' %>
 

--- a/app/views/kaminari/blacklight_compact/_paginator.html.erb
+++ b/app/views/kaminari/blacklight_compact/_paginator.html.erb
@@ -20,7 +20,7 @@
   <%= paginator.render do -%>
     <div class="page_links">
       <%= prev_page_tag %>&nbsp;&nbsp;|&nbsp;&nbsp;
-      <span class="page_entries" tabindex="0">
+      <span class="page_entries">
         Displaying
         <%= page_entries_info %>
         Results
@@ -30,7 +30,7 @@
   <% end -%>
 <% else -%>
   <div class="page_links">
-      <span class="page_entries" tabindex="0">
+      <span class="page_entries">
         <%= page_entries_info %>
       </span>
   </div>


### PR DESCRIPTION
Changes made:
- Removed unnecessary tabindex attributes
- Darkened links color. Used Color Contrast Analyzer (https://developer.paciellogroup.com/resources/contrastanalyser/) to check