### PR TITLE
Additional GPP-382 and GPP-383 Changes

### DIFF
--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -300,3 +300,15 @@ table#activity a {
 :focus{
   outline: 2px solid #337ab7 !important;
 }
+
+li.nav-item a:focus{
+  outline: 2px solid white !important;
+}
+
+a.navbar-brand:focus {
+  outline: 2px solid white !important;
+}
+
+#search-submit-header:focus {
+  outline: 2px solid orange !important;
+}

--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -309,6 +309,6 @@ a.navbar-brand:focus {
   outline: 2px solid white !important;
 }
 
-#search-submit-header:focus {
-  outline: 2px solid orange !important;
+.switch-language {
+  color: black !important;
 }

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,0 +1,22 @@
+<% # main container for facets/limits menu -%>
+<% if has_facet_values?  %>
+  <div id="facets" class="facets sidenav">
+
+    <div class="top-panel-heading panel-heading">
+      <h2 class="facets-heading" style="display: inline-block;">
+        <%= t('blacklight.search.facets.title') %>
+      </h2>
+
+      <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
+        <span class="sr-only">Filters</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+    </div>
+
+    <div id="facet-panel-collapse" class="collapse panel-group">
+      <%= render_facet_partials %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -17,7 +17,7 @@
                          aria_label: "Search Field" %>
 
       <div class="input-group-btn">
-        <button type="submit" class="btn btn-primary" id="search-submit-header" aria-label="Search">
+        <button type="submit" class="btn btn-default" id="search-submit-header" aria-label="Search">
           <%= t('hyrax.search.button.html') %>
         </button>
         <%= link_to 'More Options',

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -20,11 +20,10 @@
         <button type="submit" class="btn btn-primary" id="search-submit-header" aria-label="Search">
           <%= t('hyrax.search.button.html') %>
         </button>
-        <button class="btn btn-default" type="button" aria-label="Advanced Search Options">
-          <%= link_to 'More options',
-                      blacklight_advanced_search_engine.advanced_search_path(search_state.to_h),
-                      class: 'advanced_search underline-link' %>
-        </button>
+        <%= link_to 'More Options',
+                    blacklight_advanced_search_engine.advanced_search_path(search_state.to_h),
+                    class: 'advanced_search underline-link btn btn-default',
+                    aria: { label: 'Advanced Search Options' } %>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->
 

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -37,7 +37,7 @@
         </div>
       <% end %>
 
-        <a name="skip-to-content" id="skip-to-content" tabindex="0"></a>
+        <a id="skip-to-content"></a>
         <%= content_for?(:content) ? yield(:content) : yield %>
 
     </div><!-- /#content-wrapper -->

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -5,7 +5,7 @@
     <b class="caret"></b>
   </a>
   <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
-    <li role="presentation" class="dropdown-header"><%= t('hyrax.toolbar.language_switch') %></li>
+    <li role="presentation" class="dropdown-header switch-language"><%= t('hyrax.toolbar.language_switch') %></li>
     <li role="presentation" class="divider"></li>
     <% available_translations.each do |language, label| %>
       <li role="presentation" lang="<%= language %>">


### PR DESCRIPTION
Additional 508 changes based on Walei and Arthur's latest feedback

Changes made:
- Switched position of "Limit your search" heading and button to expand filters (this is intended for mobile view of page).
- Changed label of button to expand filters from "Toggle Facets" to "Filters".
- Changed focus outline for homepage link, language picker, and login button to white for better visibility.
- Changed color of "Go" button for better visibility with the focus outline.
- Changed "More Options" button into just a link styled as a button instead of a link inside of a button. This is to remove extra tabbing after focus is already on the button.
- Removed tabindex attribute from skip to link to remove extra tabbing and removed name attribute because it is deprecated.
