### PR TITLE
Feature/GPP-384: Replaced i18n locales with google translate widget

### DIFF
--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -300,3 +300,79 @@ table#activity a {
 :focus{
   outline: 2px solid #337ab7 !important;
 }
+
+// Google Translate styles
+.container-fluid {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.border-top {
+  border: 1px solid #e7e7e7;
+}
+
+.narrow {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 40rem;
+}
+
+.py-2 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.goog-te-combo {
+  display: inline-block;
+  width: 100%;
+  height: calc(1.5em + 1rem + 2px);
+  padding: 0.5rem 2rem 0.5rem 1rem;
+  font-size: 2rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #495057;
+  vertical-align: middle;
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 1rem center/8px 10px;
+  background-color: #fff;
+  border: 1px solid #777677;
+  border-radius: 0;
+  appearance: none;
+}
+
+.goog-te-combo {
+  -webkit-appearance: none; // Hide select arrow in Chrome
+  -moz-appearance: none; // Hide select arrow in Firefox
+}
+
+.goog-te-combo::-ms-expand {
+  display: none; // Hide select arrow in IE/Edge
+}
+
+#google_translate_element select {
+  height: calc(1.5em + 1rem + 2px);
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  font-size: 2rem;
+}
+
+#google_translate_element {
+  text-align: center;
+}
+
+#google_translate_element select {
+  margin-bottom: 0.5rem;
+}
+
+#google_translate_element .goog-logo-link {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,5 +1,9 @@
 <ul id="user_utility_links" class="nav navbar-nav navbar-right">
-  <%= render 'shared/locale_picker' if available_translations.size > 1 %>
+  <li>
+    <a data-toggle="collapse" data-target="#global-language" role="button" aria-expanded="false" aria-controls="global-langugae" aria-label="Language picker" title="Language" href="#">
+      Translate
+    </a>
+  </li>
   <% if user_signed_in? %>
     <% if current_user.nyc_employee %>
       <li>

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -5,7 +5,7 @@
     <%= content_for(:head) %>
   </head>
 
-  <body>
+  <body data-turbolinks="false">
     <% if current_user %>
       <%= auto_session_warning_tag message: "Your session will expire in approximately 5 minutes." %>
       <%= auto_session_timeout_js timeout: 1800,
@@ -20,6 +20,13 @@
     </div>
     <%= render '/nycid_header' %>
     <%= render '/masthead' %>
+
+    <div class="container-fluid border-top collapse" id="global-language">
+      <div class="narrow py-2">
+        <div id="google_translate_element"></div>
+      </div>
+    </div>
+
     <%= content_for(:navbar) %>
     <%= content_for(:precontainer_content) %>
     <div id="content-wrapper" class="container" role="main">
@@ -43,5 +50,16 @@
     </div><!-- /#content-wrapper -->
     <%= render 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>
+
+    <!-- Google Translate -->
+    <script>
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'en'
+            }, 'google_translate_element');
+        }
+    </script>
+
+    <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   </body>
 </html>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -5,7 +5,7 @@
     <%= content_for(:head) %>
   </head>
 
-  <body class="gpp-dashboard">
+  <body class="gpp-dashboard" data-turbolinks="false">
     <% if current_user %>
       <%= auto_session_warning_tag message: "Your session will expire in approximately 5 minutes." %>
       <%= auto_session_timeout_js timeout: 1800,
@@ -20,6 +20,13 @@
     </div>
     <%= render '/nycid_header' %>
     <%= render '/masthead' %>
+
+    <div class="container-fluid border-top collapse" id="global-language">
+      <div class="narrow py-2">
+        <div id="google_translate_element"></div>
+      </div>
+    </div>
+
     <%= content_for(:navbar) %>
     <div id="content-wrapper" role="main">
       <div class="sidebar maximized">
@@ -43,5 +50,16 @@
 
     </div><!-- /#content-wrapper -->
     <%= render 'shared/ajax_modal' %>
+
+    <!-- Google Translate -->
+    <script>
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'en'
+            }, 'google_translate_element');
+        }
+    </script>
+
+    <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,9 @@ module GppHyrax
     )
 
     config.local_timezone = ENV['LOCAL_TIMEZONE']
+
+    config.i18n.default_locale = :en
+    config.i18n.available_locales = [:en]
   end
 end
 


### PR DESCRIPTION
This PR replaces the i18n functionality for translations with the standard google translate widget.

Notes:
- Styles for widget are based on the NYC Core Framework. https://www1.nyc.gov/assets/doitt/html/nyc-core-framework/index.html
- In `application.rb` force default locale to English using `config.i18n.default_locale = :en`
- Disabled turbolinks globally because it was causing unintended behaviors with the google translate widget. This was done by adding the `data-turbolinks="false"` to the body in `hyrax.html.erb`