### PR TITLE
Feature/GPP-384: Google translate styles updates

### DIFF
--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -374,11 +374,13 @@ table#activity a {
   margin-right: auto;
 }
 
-body {
-  margin-bottom: 0 !important // Remove 133px margin present in default Hyrax
+// These styles prevent the overrides made by the google translate script
+html {
+  height: auto !important;
 }
 
-.site-footer {
-  // Google translate adds a position relative style to the body so we need to change the footer from absolute to relative to compensate
-  position: relative !important;
+body {
+  position: initial !important;
+  min-height: initial !important;
+  top: auto !important;
 }

--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -302,7 +302,7 @@ table#activity a {
 }
 
 // Google Translate styles
-.container-fluid {
+.container-fluid.border-top {
   width: 100%;
   padding-right: 1rem;
   padding-left: 1rem;
@@ -325,11 +325,6 @@ table#activity a {
   padding-bottom: 1rem;
 }
 
-select {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-}
-
 .goog-te-combo {
   display: inline-block;
   width: 100%;
@@ -345,6 +340,8 @@ select {
   border: 1px solid #777677;
   border-radius: 0;
   appearance: none;
+  -webkit-appearance: none; // Hide select arrow in Chrome
+  -moz-appearance: none; // Hide select arrow in Firefox
 }
 
 .goog-te-combo {
@@ -375,4 +372,13 @@ select {
 #google_translate_element .goog-logo-link {
   margin-left: auto;
   margin-right: auto;
+}
+
+body {
+  margin-bottom: 0 !important // Remove 133px margin present in default Hyrax
+}
+
+.site-footer {
+  // Google translate adds a position relative style to the body so we need to change the footer from absolute to relative to compensate
+  position: relative !important;
 }


### PR DESCRIPTION
Added a few modifications to the styles to prevent overrides to default app styles

Changes:
- Combined the `container-fluid` and `border-top` class selectors so those styles only apply to the translate section and not other elements using `container-fluid`
- Updated the select styles so that only the select with `.goog-te-combo` will be affected by custom styles
- Calling the Google translate script will automatically apply the following styles to the body tag:

position: relative;
min-height: 100%;
top: 0px;

This interferes with the spacing of the footer on very short (Contact Us) and long (Required Reports) pages. The new styles in the body and html sections will help prevent that.
