### PR TITLE
Add zipfile name to bulk import show page and email notification

### DIFF
--- a/app/mailers/bulk_import_mailer.rb
+++ b/app/mailers/bulk_import_mailer.rb
@@ -1,10 +1,11 @@
 class BulkImportMailer < ApplicationMailer
   default from: ENV['DEFAULT_FROM']
 
-  def email(importer)
+  def email(importer, filename)
     @importer = importer
-    @submitter = User.find_by(id: importer.user_id)
-    mail(to: [ENV['LIBRARY_USER_EMAIL'], @submitter],
+    @file_name = filename
+
+    mail(to: [ENV['LIBRARY_USER_EMAIL'], @importer.user.to_s],
          cc: Role.find_by(name: 'library_reviewers').users.to_a,
          subject: 'Government Publications Portal: Bulk Import Completed')
   end

--- a/app/views/bulk_import_mailer/email.erb
+++ b/app/views/bulk_import_mailer/email.erb
@@ -6,6 +6,7 @@
     <body>
         <p>Importer: <%= @importer.name %> </p>
         <p>User: <%= @importer.user %> </p>
+        <p>Filename: <%= @file_name %> </p>
         <p>Status: <%= @importer.status %> </p>
         <p>Entries Processed: <%= @importer.last_run&.processed_records %> </p>
         <p>Entries Failed: <%= @importer.last_run&.failed_records %> </p>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -20,6 +20,11 @@
       <%= @importer.user %>
     </p>
 
+    <p class="bulkrax-p-align">
+        <strong>Filename:</strong>
+        <%= @importer.parser_fields['import_file_path'].split('/')[-1] %>
+    </p>
+
     <%= render partial: 'bulkrax/shared/bulkrax_errors', locals: {item: @importer} %>
 
     </div>


### PR DESCRIPTION
This PR contains:
 - Addition of zip file name for bulk imports in the show page and email notification
 - Cleanup and deletion of imported zip file after successful import