### PR TITLE
Remove cache clearing for NYCID logout

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,7 +13,6 @@ class SessionsController < Devise::SessionsController
       user.update_attributes(unique_session_id: nil) unless duplicate
       session['saml_uid'] = saml_uid
       session['saml_session_index'] = saml_session_index
-      response.headers['Clear-Site-Data'] = '"*"'
     end
   end
 


### PR DESCRIPTION
Remove call to clear cache for NYCID logout.