### PR TITLE
File full-text search and display snippets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -91,15 +91,28 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
+    #   Include all fields available to allow searching across all attributes
     config.add_show_field solr_name("title", :stored_searchable)
-    config.add_show_field solr_name("description", :stored_searchable)
-    config.add_show_field solr_name("keyword", :stored_searchable)
+    config.add_show_field solr_name("sub_title", :stored_searchable)
+    config.add_show_field solr_name("agency", :stored_searchable)
+    config.add_show_field solr_name("required_report_name", :stored_searchable)
+    config.add_show_field solr_name("additional_creators", :stored_searchable)
     config.add_show_field solr_name("subject", :stored_searchable)
+    config.add_show_field solr_name("description", :stored_searchable)
+    config.add_show_field solr_name("date_published", :stored_searchable)
+    config.add_show_field solr_name("language", :stored_searchable)
+    config.add_show_field solr_name("fiscal_year", :stored_searchable)
+    config.add_show_field solr_name("calendar_year", :stored_searchable)
+    config.add_show_field solr_name("borough", :stored_searchable)
+    config.add_show_field solr_name("school_district", :stored_searchable)
+    config.add_show_field solr_name("community_board_district", :stored_searchable)
+    config.add_show_field solr_name("associated_place", :stored_searchable)
+    config.add_show_field solr_name("report_type", :stored_searchable)
+    config.add_show_field solr_name("keyword", :stored_searchable)
     config.add_show_field solr_name("creator", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)
     config.add_show_field solr_name("publisher", :stored_searchable)
     config.add_show_field solr_name("based_near_label", :stored_searchable)
-    config.add_show_field solr_name("language", :stored_searchable)
     config.add_show_field solr_name("date_uploaded", :stored_searchable)
     config.add_show_field solr_name("date_modified", :stored_searchable)
     config.add_show_field solr_name("date_created", :stored_searchable)
@@ -130,7 +143,7 @@ class CatalogController < ApplicationController
       all_names = config.show_fields.values.map(&:field).join(" ")
       title_name = solr_name("title", :stored_searchable)
       field.solr_parameters = {
-          qf: "#{all_names} file_format_tesim all_text_timv title_tesim sub_title_tesim agency_tesim additional_creators_tesim subject_tesim description_tesim date_published_tesim report_type_tesim language_tesim fiscal_year_tesim calendar_year_tesim borough_tesim school_district_tesim community_board_district_tesim associated_place_tesim required_report_name_tesim",
+          qf: "#{all_names} file_format_tesim all_text_timv",
           pf: title_name.to_s
       }
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -51,9 +51,15 @@ class CatalogController < ApplicationController
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
-        qt: "search",
-        rows: 10,
-        qf: "title_tesim description_tesim creator_tesim keyword_tesim"
+      qt: "search",
+      rows: 10,
+      qf: "title_tesim description_tesim creator_tesim keyword_tesim all_text_timv",
+      hl: true,
+      "hl.fl": "all_text_timv",
+      "hl.simple.pre": '<mark><em>',
+      "hl.simple.post": '</em></mark>',
+      "hl.snippets": 3,
+      "hl.fragsize": 150,
     }
 
     # solr field configuration for document/show views
@@ -88,6 +94,8 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("agency", :stored_searchable), label: "Agency", link_to_search: solr_name("agency", :facetable)
     config.add_index_field solr_name("subject", :stored_searchable), label: "Subject(s)", itemprop: 'about', link_to_search: solr_name("subject", :facetable)
     config.add_index_field solr_name("report_type", :stored_searchable), label: "Report Type", link_to_search: solr_name("report_type", :facetable)
+
+    config.add_index_field 'all_text_timv', label: 'File Text', highlight: true, if: ->(context, _field, document) { context.view_context.show_file_search_text?(document) }
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -184,6 +184,10 @@ module Hyrax
       end
     end
 
+    def show_file_search_text?(document)
+      document.response.dig(:highlighting, document.id).present?
+    end
+
     # *Sometimes* a Blacklight index field helper_method
     # @param [String,User,Hash{Symbol=>Array}] args if a hash, the user_key must be under :value
     # @return [ActiveSupport::SafeBuffer] the html_safe link

--- a/app/indexers/nyc_government_publication_indexer.rb
+++ b/app/indexers/nyc_government_publication_indexer.rb
@@ -15,6 +15,13 @@ class NycGovernmentPublicationIndexer < Hyrax::WorkIndexer
      solr_doc['title_ssi'] = object.title
      solr_doc['agency_ssi'] = object.agency
      solr_doc['date_published_ssi'] = object.date_published
+     solr_doc['all_text_timv'] = extract_text_from_filesets
    end
+  end
+
+  def extract_text_from_filesets
+    object.file_sets.map do |file_set|
+      file_set.extracted_text&.content
+    end.compact.join(" ")
   end
 end

--- a/app/search_builders/hyrax/catalog_search_builder.rb
+++ b/app/search_builders/hyrax/catalog_search_builder.rb
@@ -3,5 +3,51 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
-  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
+  self.default_processor_chain += [
+    :add_advanced_parse_q_to_solr,
+    :add_advanced_search_to_solr,
+    :show_works_that_contain_files
+  ]
+
+  def show_works_that_contain_files(solr_parameters)
+    if blacklight_params[:search_field] == 'advanced' && blacklight_params[:all_fields].present?
+      return if solr_parameters[:q].blank?
+
+      advanced_all_fields_query = advanced_all_fields_query(blacklight_params[:all_fields])
+      solr_parameters[:q] += advanced_all_fields_query
+      return
+    end
+
+    # Handle regular search
+    return if blacklight_params[:q].blank? || blacklight_params[:search_field] != 'all_fields'
+    solr_parameters[:user_query] = blacklight_params[:q]
+    solr_parameters[:q] = new_query
+    solr_parameters[:defType] = 'lucene'
+  end
+
+  private
+
+  # the {!lucene} gives us the OR syntax
+  def new_query
+    "{!lucene}#{internal_query(dismax_query)} #{internal_query(join_for_works_from_files)}"
+  end
+
+  # the _query_ allows for another parser (aka dismax)
+  def internal_query(query_value)
+    "_query_:\"#{query_value}\""
+  end
+
+  # the {!dismax} causes the query to go against the query fields
+  def dismax_query
+    "{!dismax v=$user_query}"
+  end
+
+  # join from file id to work relationship solrized file_set_ids_ssim
+  def join_for_works_from_files
+    "{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}#{dismax_query}"
+  end
+
+  def advanced_all_fields_query(all_fields_value)
+    " _query_:\"{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}""{!dismax qf=all_text_timv}#{all_fields_value}\""
+  end
 end

--- a/app/search_builders/hyrax/catalog_search_builder.rb
+++ b/app/search_builders/hyrax/catalog_search_builder.rb
@@ -10,17 +10,15 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
   ]
 
   def show_works_that_contain_files(solr_parameters)
-    if blacklight_params[:search_field] == 'advanced' && blacklight_params[:all_fields].present?
-      return if solr_parameters[:q].blank?
+    return unless blacklight_params[:search_field] == 'advanced'
 
-      advanced_all_fields_query = advanced_all_fields_query(blacklight_params[:all_fields])
-      solr_parameters[:q] += advanced_all_fields_query
-      return
-    end
+    # Don't overwrite if add_advanced_search_to_solr already handled
+    return if solr_parameters[:q].present?
 
-    # Handle regular search
-    return if blacklight_params[:q].blank? || blacklight_params[:search_field] != 'all_fields'
-    solr_parameters[:user_query] = blacklight_params[:q]
+    user_query = blacklight_params[:q] || blacklight_params[:all_fields]
+    return if user_query.blank?
+
+    solr_parameters[:user_query] = user_query
     solr_parameters[:q] = new_query
     solr_parameters[:defType] = 'lucene'
   end
@@ -48,6 +46,6 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
   end
 
   def advanced_all_fields_query(all_fields_value)
-    " _query_:\"{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}""{!dismax qf=all_text_timv}#{all_fields_value}\""
+    " _query_:\"{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}{!dismax qf=all_text_timv}#{all_fields_value}\""
   end
 end

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -4,7 +4,6 @@
 
   <h1 class="advanced page-header">
     <%= t('blacklight_advanced_search.form.title') %>
-    <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-default pull-right advanced-search-start-over" %>
   </h1>
 
   <div class="row">

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,9 +1,16 @@
 <% if query_has_constraints? %>
 
   <div id="appliedParams" class="clearfix constraints-container">
-    <div class="pull-right">
-      <%=link_to t('blacklight.search.start_over'), start_over_path, :class => "catalog_startOverLink btn btn-sm btn-text underline-link", :id=>"startOverLink" %>
-    </div>
+      <div class="pull-right">
+          <% advanced_search = params[:search_field] == 'advanced' %>
+          <% redirect_path = advanced_search ? blacklight_advanced_search_engine.advanced_search_path : start_over_path %>
+
+          <% if advanced_search %>
+              <%= link_to "Modify Search", blacklight_advanced_search_engine.advanced_search_path(search_state&.to_h || {}), class: "btn btn-default me-2" %>
+          <% end %>
+
+          <%= link_to t('blacklight.search.start_over'), redirect_path, class: "catalog_startOverLink btn btn-default advanced-search-start-over ", id: "startOverLink" %>
+      </div>
     <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
     <%= render_constraints(params) %>
   </div>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,7 +1,6 @@
 <%= form_tag search_form_action, method: :get, class: "form-horizontal search-form", id: "search-form-header", role: "search" do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <%= hidden_field_tag :search_field, 'all_fields' %>
-  <%= hidden_field_tag :search_field, 'member_of_collection_ids' %>
   <div class="form-group">
 
     <label class="control-label col-sm-3" for="search-field-header">
@@ -22,7 +21,7 @@
         </button>
         <button class="btn btn-default" type="button" aria-label="Advanced Search Options">
           <%= link_to 'More options',
-                      blacklight_advanced_search_engine.advanced_search_path(search_state.to_h),
+                      blacklight_advanced_search_engine.advanced_search_path,
                       class: 'advanced_search underline-link' %>
         </button>
       </div><!-- /.input-group-btn -->

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,7 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+
+    search:
+      zero_results:
+        use_fewer_keywords: "Use fewer keywords to start, then refine your search using the links shown above."


### PR DESCRIPTION
This pull request contains:

- Full-text search for files in works
- Display of matching text snippets in search results when a match is found

NOTE: Stored must be changed to "true" in Solr schema.xml for the "all_text_timv" field

```
<field name="all_text_timv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
```

Existing works must be re-indexed to return text in search results. In the Rails console, run:

```
ActiveFedora::Base.reindex_everything
```