### PR TITLE
Add Agency Contacts Management and Enhance Mandated Reports Form

### DIFF
--- a/app/assets/javascripts/agency_contacts.js
+++ b/app/assets/javascripts/agency_contacts.js
@@ -1,0 +1,123 @@
+$(document).ready(function () {
+    const agencyId = $("#agency").data("agency-id");
+    const emailForm = $("#add-email-form");
+    const emailInput = $("#new-email-input");
+    const emailError = $("#email-error-message");
+    const deleteEmailBtn = $("#delete-email-btn");
+    const checkAll = $("#check_all");
+    const agencyFlashMessage = $("#agency-flash-message");
+    const agencyContactRows = $("#agency-contact-rows");
+
+    registerEventHandlers();
+
+    function registerEventHandlers() {
+        $(document)
+            .on("change", "#check_all", toggleAllCheckboxes)
+            .on("change", ".email-checkbox", toggleDeleteBtn)
+            .on("submit", "#add-email-form", addEmail)
+            .on("click", "#delete-email-btn", deleteSelectedEmail)
+            .on("mousedown", resetEmailState);
+    }
+
+    function toggleAllCheckboxes() {
+        $(".email-checkbox").prop("checked", this.checked);
+        toggleDeleteBtn();
+    }
+
+    function toggleDeleteBtn() {
+        // Toggle delete button based on whether any checkboxes are selected
+        deleteEmailBtn.toggle($(".email-checkbox:checked").length > 0);
+    }
+
+    function showFlashMessage(message, type = "success") {
+        agencyFlashMessage
+            .attr("class", `alert alert-${type}`)
+            .attr("role", "alert")
+            .text(message)
+            .fadeIn()
+            .delay(3000)
+            .fadeOut();
+    }
+
+    function refreshContactsTable(html) {
+        const agencyContactsTable = $(".agency-contacts-table");
+
+        // Reset DataTable
+        if ($.fn.DataTable.isDataTable(agencyContactsTable)) {
+            agencyContactsTable.DataTable().destroy();
+        }
+
+        // Repopulate table rows
+        agencyContactRows.html(html);
+
+        agencyContactsTable.DataTable({
+            destroy: true,
+            columnDefs: [{ orderable: false, targets: "no-sort" }]
+        });
+
+        // Uncheck "check all" and update delete button state
+        checkAll.prop("checked", false);
+        toggleDeleteBtn();
+    }
+
+    function resetEmailState() {
+        emailForm.removeClass("has-error");
+        emailError.hide().text("");
+    }
+
+    function addEmail(e) {
+        e.preventDefault();
+
+        // Perform HTML5 validation on the input
+        if (!emailInput[0].checkValidity()) {
+            emailInput[0].reportValidity();
+            return false;
+        }
+
+        const email = emailInput.val();
+
+        $.ajax({
+            url: `/agency_contacts`,
+            method: "POST",
+            data: { new_email: email, id: agencyId },
+            dataType: "json",
+            success: function (response) {
+                emailInput.val("");
+                resetEmailState();
+                showFlashMessage(response.message || "Email added successfully");
+                refreshContactsTable(response.html);
+            },
+            error: function (xhr) {
+                const errorMsg = xhr.responseJSON?.error || "Something went wrong.";
+                emailForm.addClass("has-error");
+                emailError.addClass("has-error").text(errorMsg).show();
+            }
+        });
+    }
+
+    function deleteSelectedEmail(e) {
+        e.preventDefault();
+
+        const indices = $(".email-checkbox:checked")
+            .map(function () {
+                return $(this).val();
+            })
+            .get();
+
+        if (indices.length === 0 || !confirm("Are you sure you want to delete the selected email(s)?")) return;
+
+        $.ajax({
+            url: `/agency_contacts/${agencyId}`,
+            method: "DELETE",
+            data: { indices },
+            dataType: "json",
+            success: function (response) {
+                showFlashMessage(response.message || "Email(s) deleted.");
+                refreshContactsTable(response.html);
+            },
+            error: function () {
+                alert("Failed to delete email(s).");
+            }
+        });
+    }
+});

--- a/app/assets/javascripts/agency_contacts.js
+++ b/app/assets/javascripts/agency_contacts.js
@@ -88,7 +88,7 @@ $(document).ready(function () {
                 refreshContactsTable(response.html);
             },
             error: function (xhr) {
-                const errorMsg = xhr.responseJSON?.error || "Something went wrong.";
+                const errorMsg = (xhr.responseJSON && xhr.responseJSON.error) || "Something went wrong.";
                 emailForm.addClass("has-error");
                 emailError.addClass("has-error").text(errorMsg).show();
             }

--- a/app/assets/stylesheets/gpp.scss
+++ b/app/assets/stylesheets/gpp.scss
@@ -395,3 +395,35 @@ body {
   background-color: #FFFF00;
   padding: 2px;
 }
+
+/* Agency Contact table styles */
+table.dataTable thead th.col-name {
+  width: 50%;
+}
+
+// Disable sort on columns with buttons
+th.no-sort::after,
+th.no-sort::before {
+  display: none !important;
+}
+
+#add-email-form {
+  max-width: 400px;
+}
+
+// Set width of checkbox column
+.email-checkbox {
+  max-width:50px;
+  margin: 0;
+}
+
+// Set position of flash message
+#agency-flash-message {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 9999;
+  min-width: 200px;
+  padding: 10px 15px;
+  border-radius: 4px;
+}

--- a/app/controllers/agency_contacts_controller.rb
+++ b/app/controllers/agency_contacts_controller.rb
@@ -1,0 +1,94 @@
+class AgencyContactsController < ApplicationController
+  include Hyrax::ThemedLayoutController
+  before_action :authenticate_user!
+  before_action :ensure_authorized!
+  before_action :set_agency, only: [:edit, :create, :destroy]
+  with_themed_layout 'dashboard'
+
+  def index
+    @agencies = Agency.all
+    add_agency_breadcrumbs
+  end
+
+  def edit
+    @emails = @agency.point_of_contact_emails || []
+    add_agency_breadcrumbs
+    add_breadcrumb "Edit", edit_agency_contact_path(@agency)
+  end
+
+  def create
+    email = params[:new_email].to_s.strip
+
+    if !valid_email?(email)
+      return render json: { error: "Invalid email address." }, status: :unprocessable_entity
+    elsif @agency.point_of_contact_emails&.include?(email)
+      return render json: { error: "Email already exists." }, status: :unprocessable_entity
+    end
+
+    @agency.point_of_contact_emails << email
+
+    if @agency.save
+      render_email_rows(message: "Email added successfully")
+    else
+      render json: { error: "Failed to save email." }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    indices = Array(params[:indices]).map(&:to_i)
+    emails = @agency.point_of_contact_emails || []
+
+    # Reverse sort the indices to ensure shifting doesn't change the index of the email we're removing
+    indices.sort.reverse.each do |index|
+      emails.delete_at(index)
+    end
+
+    if @agency.update(point_of_contact_emails: emails)
+      render_email_rows(message: "Selected email(s) have been successfully removed.")
+    else
+      render json: { error: "Failed to delete email(s)." }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_agency
+    @agency = Agency.find(params[:id])
+
+    if @agency.point_of_contact_emails.nil?
+      @agency.point_of_contact_emails = []
+    end
+
+    @emails = @agency.point_of_contact_emails
+  end
+
+  def valid_email?(email)
+    # Ensure the email does not contain any spaces
+    return false if email.blank? || email.match?(/\s/)
+
+    # Validate using the general EMAIL_REGEXP
+    return false unless email.match?(URI::MailTo::EMAIL_REGEXP)
+
+    # Check for the presence of a domain
+    domain_regex = /\A[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}\z/
+    domain = email.split('@').last
+    domain.match?(domain_regex)
+  end
+
+  def render_email_rows(message: nil)
+    render json: {
+      html: render_to_string(partial: 'agency_contacts/email_rows',locals: { emails: @emails, agency: @agency }),
+      message: message
+    }
+  end
+
+  def add_agency_breadcrumbs
+    add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+    add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+    add_breadcrumb 'Agency Contacts', main_app.agency_contacts_path
+  end
+
+  def ensure_authorized!
+    authorize! :review, :submissions
+  end
+end

--- a/app/controllers/agency_contacts_controller.rb
+++ b/app/controllers/agency_contacts_controller.rb
@@ -85,7 +85,7 @@ class AgencyContactsController < ApplicationController
   def add_agency_breadcrumbs
     add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
     add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-    add_breadcrumb 'Agency Contacts', main_app.agency_contacts_path
+    add_breadcrumb t(:'hyrax.admin.sidebar.agency_contacts'), main_app.agency_contacts_path
   end
 
   def ensure_authorized!

--- a/app/controllers/agency_contacts_controller.rb
+++ b/app/controllers/agency_contacts_controller.rb
@@ -17,7 +17,7 @@ class AgencyContactsController < ApplicationController
   end
 
   def create
-    email = params[:new_email].to_s.strip
+    email = params[:new_email].to_s.downcase.strip
 
     if !valid_email?(email)
       return render json: { error: "Invalid email address." }, status: :unprocessable_entity

--- a/app/controllers/required_reports_controller.rb
+++ b/app/controllers/required_reports_controller.rb
@@ -157,6 +157,6 @@ class RequiredReportsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def required_report_params
-      params.require(:required_report).permit(:agency_name, :name, :description, :local_law, :charter_and_code, :automated_date, :frequency, :frequency_integer, :other_frequency_description, :start_date, :end_date, :last_published_date, :is_visible)
+      params.require(:required_report).permit(:agency_name, :name, :description, :local_law, :charter_and_code, :automated_date, :frequency, :frequency_integer, :other_frequency_description, :start_date, :end_date, :last_published_date, :required_distribution, :report_deadline, :additional_notes, :is_visible)
     end
 end

--- a/app/decorators/agency_contacts_controller_decorator.rb
+++ b/app/decorators/agency_contacts_controller_decorator.rb
@@ -1,0 +1,13 @@
+class AgencyContactsControllerDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/helpers/agency_contacts_controller_helper.rb
+++ b/app/helpers/agency_contacts_controller_helper.rb
@@ -1,0 +1,2 @@
+module AgencyContactsControllerHelper
+end

--- a/app/views/agency_contacts/_email_rows.html.erb
+++ b/app/views/agency_contacts/_email_rows.html.erb
@@ -1,0 +1,8 @@
+<div id="agency-flash-message" class="alert alert-success" style="display: none;"></div>
+
+<% emails.each_with_index do |email, i| %>
+  <tr data-index="<%= i %>">
+    <td><%= check_box_tag "email_indices[]", i, false, id: "email_checkbox_#{i}", class: "email-checkbox"%></td>
+    <td><%= email %></td>
+  </tr>
+<% end %>

--- a/app/views/agency_contacts/edit.html.erb
+++ b/app/views/agency_contacts/edit.html.erb
@@ -1,0 +1,47 @@
+<div id="agency" data-agency-id="<%= @agency.id %>">
+  <%= javascript_include_tag 'agency_contacts.js' %>
+  <% provide :page_header do %>
+    <h1><span class="fa fa-pencil-square-o" aria-hidden="true"></span> <%= @agency.name %></h1>
+    <button id="delete-email-btn" class="btn btn-danger" style="display: none;">Delete Selected</button>
+    <form id="add-email-form" class="pull-right">
+      <div class="input-group">
+        <input type="email" id="new-email-input" placeholder="New point of contact email" class="form-control" required />
+        <div class="input-group-btn">
+          <button id="add-email-btn" class="btn btn-primary">Add Email</button>
+        </div>
+      </div>
+      <div id="email-error-message" class="help-block" style="display: none; "></div>
+    </form>
+  <% end %>
+
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <div class="table-responsive">
+        <table class="table table-striped datatable agency-contacts-table">
+          <thead>
+            <tr>
+              <th scope="col" class="check-all no-sort email-checkbox">
+                <%= check_box_tag "check_all", "", false, id: "check_all", style:"margin:0px;"%> <span>Select</span>
+              </th>
+              <th scope="col">Point of Contact Email</th>
+            </tr>
+          </thead>
+          <tbody id="agency-contact-rows">
+            <%= render partial: 'agency_contacts/email_rows', locals: { emails: @emails, agency: @agency } %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+    $(function() {
+        $('.agency-contacts-table').DataTable({
+            destroy: true,
+            columnDefs: [
+                { orderable: false, targets: 'no-sort' }
+            ]
+        });
+    });
+</script>

--- a/app/views/agency_contacts/index.html.erb
+++ b/app/views/agency_contacts/index.html.erb
@@ -1,0 +1,40 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-address-card" aria-hidden="true"></span> Agency Contacts</h1>
+<% end %>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+    <div class="table-responsive">
+      <table class="table table-striped datatable agency-contacts">
+        <thead>
+          <th scope="col" class="col-name">Name</th>
+          <th scope="col">Point of Contact Email(s)</th>
+          <th scope="col" class="no-sort"></th>
+        </thead>
+        <tbody>
+          <% if @agencies.present? %>
+            <% @agencies.each do |agency| %>
+              <tr>
+                <td><%= agency.name %></td>
+                <td><%= agency.point_of_contact_emails&.join(", ") %></td>
+                <td>
+                  <%= link_to "Edit", edit_agency_contact_path(agency), class: "btn btn-sm btn-primary ml-2" %>
+                </td>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<script>
+    $(function() {
+      $('#agency-contacts').DataTable({
+          destroy: true,
+          columnDefs: [
+              { orderable: false, targets: 'no-sort' }
+          ]
+      });
+    });
+</script>

--- a/app/views/agency_contacts/index.html.erb
+++ b/app/views/agency_contacts/index.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-address-card" aria-hidden="true"></span> Agency Contacts</h1>
+  <h1><span class="fa fa-address-card" aria-hidden="true"></span> Manage Agency Contacts</h1>
 <% end %>
 
 <div class="panel panel-default">

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -1,0 +1,26 @@
+  <% if can? :review, :submissions %>
+    <li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
+    <%= menu.nav_link(hyrax.admin_workflows_path) do %>
+      <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
+    <% end %>
+
+    <%= menu.nav_link(main_app.agency_contacts_path) do %>
+      <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.agency_contacts') %></span>
+    <% end %>
+  <% end %>
+
+  <% if can? :manage, User %>
+    <%= menu.nav_link(hyrax.admin_users_path) do %>
+      <span class="fa fa-user" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
+    <% end %>
+  <% end %>
+
+  <% if can? :read, :admin_dashboard %>
+    <%= menu.nav_link(hyrax.embargoes_path) do %>
+      <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.embargoes.index.manage_embargoes') %></span>
+    <% end %>
+
+    <%= menu.nav_link(hyrax.leases_path) do %>
+      <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.leases.index.manage_leases') %></span>
+    <% end %>
+  <% end %>

--- a/app/views/required_reports/_form.html.erb
+++ b/app/views/required_reports/_form.html.erb
@@ -77,6 +77,21 @@
               input_html: { class: 'form-control', multiple: false, placeholder: 'YYYY-MM-DD' }
   %>
 
+  <%= f.input :required_distribution,
+              as: :string,
+              input_html: { class: 'form-control'}
+  %>
+
+  <%= f.input :report_deadline,
+              as: :string,
+              input_html: { class: 'form-control'}
+  %>
+
+  <%= f.input :additional_notes,
+              as: :text,
+              input_html: { class: 'form-control', rows: 3, maxlength: 500 }
+  %>
+
   <div class="actions">
     <%= f.button :submit,
                  class: 'btn btn-primary'

--- a/app/views/required_reports/_required_report.json.jbuilder
+++ b/app/views/required_reports/_required_report.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! required_report, :id, :agency, :name, :description, :local_law, :charter_and_code, :automated_date, :frequency, :frequency_integer, :other_frequency_description, :start_date, :end_date, :last_published_date, :created_at, :updated_at
+json.extract! required_report, :id, :agency, :name, :description, :local_law, :charter_and_code, :automated_date, :frequency, :frequency_integer, :other_frequency_description, :start_date, :end_date, :last_published_date, :required_distribution, :report_deadline, :additional_notes, :created_at, :updated_at
 json.url mandated_report_url(required_report, format: :json)

--- a/app/views/required_reports/new.html.erb
+++ b/app/views/required_reports/new.html.erb
@@ -1,3 +1,4 @@
+<% provide :page_title, construct_page_title('New Mandated Report') %>
 <h1>New Mandated Report</h1>
 
 <%= render 'form', required_report: @required_report %>

--- a/app/views/required_reports/public_list.html.erb
+++ b/app/views/required_reports/public_list.html.erb
@@ -50,12 +50,15 @@
       <th class="col-md-1">Last Published Date</th>
       <th class="col-md-1">See All Reports</th>
       <% if @is_admin %>
-         <th class="col-md-1" style="white-space: nowrap;">
-             Show <i class="glyphicon glyphicon-info-sign"
-                          data-toggle="show-hide-tooltip"
-                          data-placement="bottom"
-                          title="Toggle visibility of reports on the public list."></i>
-         </th>
+        <th class="col-md-1">Required Distribution</th>
+        <th class="col-md-1">Report Deadline</th>
+        <th class="col-md-1">Additional Notes</th>
+        <th class="col-md-1" style="white-space: nowrap;">
+          Show <i class="glyphicon glyphicon-info-sign"
+                  data-toggle="show-hide-tooltip"
+                  data-placement="bottom"
+                  title="Toggle visibility of reports on the public list."></i>
+        </th>
       <% end %>
     </tr>
     </thead>
@@ -87,13 +90,16 @@
                         label: format('Search all, %s for %s', required_report.name, required_report.agency_name)
                       } %></td>
         <% if @is_admin %>
-              <td>
-                  <input type="checkbox"
-                         name="admin_checkbox"
-                         class="visibility-checkbox"
-                         data-report-id="<%= required_report.id %>"
-                         <%= required_report.is_visible ? 'checked' : '' %> />
-              </td>
+          <td><%= required_report.required_distribution %></td>
+          <td><%= required_report.report_deadline %></td>
+          <td><%= required_report.additional_notes %></td>
+          <td>
+            <input type="checkbox"
+                   name="admin_checkbox"
+                   class="visibility-checkbox"
+                   data-report-id="<%= required_report.id %>"
+                   <%= required_report.is_visible ? 'checked' : '' %> />
+          </td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/required_reports/show.html.erb
+++ b/app/views/required_reports/show.html.erb
@@ -1,3 +1,5 @@
+<% provide :page_title, construct_page_title('Show Mandated Reports') %>
+
 <p id="notice"><%= notice %></p>
 
 <p>
@@ -60,5 +62,20 @@
   <%= @required_report.last_published_date %>
 </p>
 
-<!--<%#= link_to 'Edit', edit_required_report_path(@required_report) %> |-->
+<p>
+  <strong>Required Distribution:</strong>
+  <%= @required_report.required_distribution %>
+</p>
+
+<p>
+  <strong>Report Deadline:</strong>
+  <%= @required_report.report_deadline %>
+</p>
+
+<p>
+  <strong>Additional Notes:</strong>
+  <%= @required_report.additional_notes %>
+</p>
+
+<!--<%#= link_to 'Edit', edit_mandated_report_path(@required_report) %> |-->
 <%= link_to 'Back', mandated_reports_path %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,4 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w( gpp/save_work/save_work_control.es6 required_reports.js required_reports_filters.js bulkrax/importers.js.erb)
+Rails.application.config.assets.precompile += %w( gpp/save_work/save_work_control.es6 required_reports.js required_reports_filters.js bulkrax/importers.js.erb agency_contacts.js)

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -47,6 +47,9 @@ en:
           title_tesim: Title
   hyrax:
     account_name: My Institution Account Id
+    admin:
+      sidebar:
+        agency_contacts: Manage Agency Contacts
     controls:
       contact: Contact Us
       manage_mandated_reports: Manage Mandated Reports

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :agency_contacts, only: [:index, :edit, :create, :destroy]
+
   # Catch all route for any routes that don't exist. Always have this as the last route
   match '*path', to: 'errors#not_found', via: :all, format: false, defaults: { format: 'html' }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20250605143718_add_fields_to_required_reports.rb
+++ b/db/migrate/20250605143718_add_fields_to_required_reports.rb
@@ -1,0 +1,7 @@
+class AddFieldsToRequiredReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :required_reports, :required_distribution, :string
+    add_column :required_reports, :report_deadline, :string
+    add_column :required_reports, :additional_notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_01_141507) do
+ActiveRecord::Schema.define(version: 2025_06_05_143718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -443,6 +443,9 @@ ActiveRecord::Schema.define(version: 2024_08_01_141507) do
     t.datetime "updated_at", null: false
     t.boolean "automated_date", default: true, null: false
     t.boolean "is_visible", default: true, null: false
+    t.string "required_distribution"
+    t.string "report_deadline"
+    t.text "additional_notes"
   end
 
   create_table "roles", id: :serial, force: :cascade do |t|

--- a/spec/controllers/agency_contacts_controller_spec.rb
+++ b/spec/controllers/agency_contacts_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AgencyContactsController, type: :controller do
+
+end

--- a/spec/decorators/agency_contacts_controller_decorator_spec.rb
+++ b/spec/decorators/agency_contacts_controller_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe AgencyContactsControllerDecorator do
+end

--- a/spec/helpers/agency_contacts_controller_helper_spec.rb
+++ b/spec/helpers/agency_contacts_controller_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AgencyContactsControllerHelper. For example:
+#
+# describe AgencyContactsControllerHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe AgencyContactsControllerHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR contains:
  - Addition of an agency point of contacts management feature.
  - New fields added to the mandated reports creation form.

Run the following after pulling these changes:
```
rails db:migrate
rake assets:precompile   
```
