### PR TITLE
Sv sprint 02

### DIFF
--- a/app/assets/javascripts/required_reports.js
+++ b/app/assets/javascripts/required_reports.js
@@ -19,7 +19,7 @@ $(document).ready(function () {
             min: '01/01/1600'
         });
 
-    $('#new_required_report').submit(function (e) {
+    $('.new_required_report, .edit_required_report').submit(function (e) {
         let local_law_value_length = $('#required_report_local_law').val().length,
             charter_and_code_value_length = $('#required_report_charter_and_code').val().length,
             frequency_value = $('#required_report_frequency').val(),
@@ -61,9 +61,13 @@ $(document).ready(function () {
 
     // Display an error message to the user
     function showError(message) {
-        let errorDiv = $('#new_required_report #alert-error');
-        errorDiv.text(message);
-        errorDiv.show();
+        let errorDiv = $('#alert-error');
+        errorDiv.text(message).show().focus();
+    }
+
+    // Focus server-side errors on page load
+    const errorDiv = $('#alert-error[data-has-server-errors="true"]');
+    if (errorDiv.length > 0) {
         errorDiv.focus();
     }
 });

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -52,11 +52,9 @@ module Hyrax
 
     def create
       if actor.create(actor_environment)
-        # Update RequiredReportDueDate date_submitted
         report_due_date_id = params[hash_key_for_curation_concern]['report_due_date_id']
         if report_due_date_id.present?
-          required_report_due_date = RequiredReportDueDate.where(id: params[hash_key_for_curation_concern]['report_due_date_id']).first
-          required_report_due_date.update_attributes(submission_id: curation_concern.id, date_submitted: Time.current)
+          Gpp::UpdateDueDateSubmissionJob.perform_later(report_due_date_id, curation_concern.id)
         end
 
         after_create_response
@@ -118,30 +116,31 @@ module Hyrax
     def destroy
       title = curation_concern.to_s
       agency = curation_concern.agency
-      required_report_name = curation_concern.required_report_name
+      mandated_report_name = curation_concern.required_report_name
       submission_id = curation_concern.id
+      metadata = nil
 
       # Check that the work has been published before storing metadata
-      if !(curation_concern.suppressed?)
+      unless curation_concern.suppressed?
         metadata = {
-            id: curation_concern.id,
-            date_uploaded: curation_concern.date_uploaded.to_s,
-            title: title,
-            sub_title: curation_concern.sub_title,
-            agency: agency,
-            required_report_name: required_report_name,
-            additional_creators: curation_concern.additional_creators,
-            subject: curation_concern.subject,
-            description: curation_concern.description,
-            date_published: curation_concern.date_published,
-            report_type: curation_concern.report_type,
-            language: curation_concern.language,
-            fiscal_year: curation_concern.fiscal_year,
-            calendar_year: curation_concern.calendar_year,
-            borough: curation_concern.borough,
-            school_district: curation_concern.school_district,
-            community_board_district: curation_concern.community_board_district,
-            associated_place: curation_concern.associated_place
+          id: curation_concern.id,
+          date_uploaded: curation_concern.date_uploaded.to_s,
+          title: title,
+          sub_title: Array(curation_concern.sub_title).first.to_s,
+          agency: agency,
+          required_report_name: mandated_report_name,
+          additional_creators: Array(curation_concern.additional_creators).map(&:to_s),
+          subject: Array(curation_concern.subject).map(&:to_s),
+          description: Array(curation_concern.description).first.to_s,
+          date_published: Array(curation_concern.date_published).first.to_s,
+          report_type: Array(curation_concern.report_type).first.to_s,
+          language: Array(curation_concern.language).map(&:to_s),
+          fiscal_year: Array(curation_concern.fiscal_year).map(&:to_s),
+          calendar_year: Array(curation_concern.calendar_year).map(&:to_s),
+          borough: Array(curation_concern.borough).map(&:to_s),
+          school_district: Array(curation_concern.school_district).map(&:to_s),
+          community_board_district: Array(curation_concern.community_board_district).map(&:to_s),
+          associated_place: Array(curation_concern.associated_place).map(&:to_s),
         }
       end
 
@@ -149,37 +148,8 @@ module Hyrax
       return unless actor.destroy(env)
       Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
 
-      # Query for publications with required_report
-      publications = NycGovernmentPublication.where(required_report_name: required_report_name,
-                                                    agency: agency)
-                                             .order('date_published_ssi desc')
-      required_report = RequiredReport.where(agency_name: agency, name: required_report_name).first
-      required_report_due_date = RequiredReportDueDate.where(submission_id: submission_id).first
-
-      # Store deleted work's metadata in deleted_publications
-      if metadata.present?
-        metadata[:required_report_due_date_id] = required_report_due_date.id unless required_report_due_date.nil?
-        DeletedPublication.create(user_guid: current_user.guid,
-                                  timestamp: Time.current,
-                                  metadata: metadata)
-      end
-
-      # If there are no previous publications, set date_published to nil
-      if publications.present?
-        publications.each do |p|
-          if !(p.suppressed?) && p.required_report_name != "Not Required" && p.required_report_name != "Other Publication"
-            # Set required_report.date_published to the publication with the next chronological published date
-            required_report.update_attributes(last_published_date: p.date_published)
-            break
-          end
-        end
-      else
-        required_report.update_attributes(last_published_date: nil) unless required_report.nil?
-      end
-
-      # Set submission_id and date_submitted to nil in required_report_due_dates
-      required_report_due_date.update_attributes(submission_id: nil,
-                                                 date_submitted: nil) unless required_report_due_date.nil?
+      # Save work metadata to the database and update mandated reports
+      Gpp::DeletePublicationJob.perform_later(metadata, submission_id, agency, mandated_report_name, current_user.guid)
 
       after_destroy_response(title)
     end

--- a/app/controllers/hyrax/workflow_actions_controller.rb
+++ b/app/controllers/hyrax/workflow_actions_controller.rb
@@ -55,29 +55,7 @@ module Hyrax
       required_report_name = work.required_report_name
       return if ['Not Required', 'Other Publication'].include?(required_report_name)
 
-      date_published = Date.parse(work.date_published)
-      # Find all required reports for the specified agency and name
-      required_reports = RequiredReport.where(agency_name: work.agency, name: required_report_name)
-      # Search for a required report with no end_date. If none, select the first report found
-      required_report = required_reports.find_by(end_date: nil) || required_reports.first
-
-      case workflow_action_name
-      when 'comment_only'
-        return
-      when 'approve'
-        # Set last_published_date if work is approved and date_published is after current value of last_published_date
-        if required_report.last_published_date.nil? || (date_published > required_report.last_published_date)
-          required_report.update(last_published_date: date_published)
-        end
-      when 'request_changes'
-        # Set date_submitted to nil on request_changes
-        required_report_due_date = RequiredReportDueDate.where(submission_id: work.id).first
-        required_report_due_date&.update(date_submitted: nil)
-      when 'request_review'
-        # Set date_submitted to current date and time on request_review
-        required_report_due_date = RequiredReportDueDate.where(submission_id: work.id).first
-        required_report_due_date&.update(date_submitted: Time.current)
-      end
+      Gpp::UpdateMandatedReportJob.perform_later(work.id, workflow_action_name)
     end
   end
 end

--- a/app/controllers/required_reports_controller.rb
+++ b/app/controllers/required_reports_controller.rb
@@ -118,15 +118,11 @@ class RequiredReportsController < ApplicationController
     params[:per_page] ||= 20
     params[:agency] ||= 'All'
 
-    # Determine if the current user is an admin
-    @is_admin = user_signed_in? && (current_user.admin? || current_user.library_reviewers?)
+    # Determine if the current user has permission to manage reports
+    @can_manage_reports = can?(:update, RequiredReport)
 
-    # Build the base query with visibility conditions based on user role
-    base_query = if @is_admin
-                   RequiredReport.all
-                 else
-                   RequiredReport.where(is_visible: true)
-                 end
+    # Build the base query with visibility conditions based on user permission
+    base_query = @can_manage_reports ? RequiredReport.all : RequiredReport.where(is_visible: true)
 
     # Apply agency filter to the base query
     @required_reports = if params[:agency] == 'All'

--- a/app/controllers/required_reports_controller.rb
+++ b/app/controllers/required_reports_controller.rb
@@ -2,8 +2,8 @@
 
 class RequiredReportsController < ApplicationController
   load_and_authorize_resource except: :public_list
-  # Removed :edit, :update, :destroy actions from 'only' for now
-  before_action :set_required_report, only: [:show]
+  # Removed :destroy actions from 'only' for now
+  before_action :set_required_report, only: [:show, :edit, :update]
 
   # GET /required_reports
   # GET /required_reports.json
@@ -36,8 +36,8 @@ class RequiredReportsController < ApplicationController
   end
 
   # GET /required_reports/1/edit
-  # def edit
-  # end
+  def edit
+  end
 
   # POST /required_reports
   # POST /required_reports.json
@@ -58,8 +58,8 @@ class RequiredReportsController < ApplicationController
 
     respond_to do |format|
       if @required_report.save
+        log_mandated_report_event(@required_report, :created)
         path = mandated_report_path(@required_report)
-
         format.html { redirect_to path, notice: 'Mandated Report was successfully created.' }
         format.json { render :show, status: :created, location: path }
       else
@@ -71,17 +71,18 @@ class RequiredReportsController < ApplicationController
 
   # PATCH/PUT /required_reports/1
   # PATCH/PUT /required_reports/1.json
-  # def update
-  #   respond_to do |format|
-  #     if @required_report.update(required_report_params)
-  #       format.html { redirect_to @required_report, notice: 'Required report was successfully updated.' }
-  #       format.json { render :show, status: :ok, location: @required_report }
-  #     else
-  #       format.html { render :edit }
-  #       format.json { render json: @required_report.errors, status: :unprocessable_entity }
-  #     end
-  #   end
-  # end
+  def update
+    respond_to do |format|
+      if @required_report.update(required_report_params)
+        log_mandated_report_event(@required_report,:updated, @required_report.previous_changes)
+        format.html { redirect_to mandated_report_path(@required_report), notice: 'Mandated report was successfully updated.' }
+        format.json { render :show, status: :ok, location: mandated_report_path(@required_report) }
+      else
+        format.html { render :edit }
+        format.json { render json: @required_report.errors, status: :unprocessable_entity }
+      end
+    end
+  end
 
   # DELETE /required_reports/1
   # DELETE /required_reports/1.json
@@ -143,6 +144,7 @@ class RequiredReportsController < ApplicationController
 
   def toggle_visibility
     if @required_report.update(is_visible: params[:required_report][:is_visible])
+      log_mandated_report_event(@required_report, :visibility_updated, @required_report.previous_changes)
       render json: { success: true }
     else
       render json: { success: false, error: @required_report.errors.full_messages }, status: :unprocessable_entity
@@ -154,6 +156,25 @@ class RequiredReportsController < ApplicationController
     def set_required_report
       @required_report = RequiredReport.find(params[:id])
     end
+
+  def log_mandated_report_event(required_report, event_type, changes = nil)
+    if changes
+      filtered_changes = changes.except(:updated_at)
+      previous_value = filtered_changes.transform_values(&:first)
+      new_value = filtered_changes.transform_values(&:last)
+    else
+      previous_value = nil
+      new_value = required_report.attributes
+    end
+
+    Gpp::MandatedReportEvent.create!(
+      required_report: required_report,
+      user: current_user,
+      event_type: event_type,
+      previous_value: previous_value,
+      new_value: new_value
+    )
+  end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def required_report_params

--- a/app/jobs/gpp/delete_publication_job.rb
+++ b/app/jobs/gpp/delete_publication_job.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+module Gpp
+  class DeletePublicationJob < ApplicationJob
+    queue_as :default
+
+    def perform(metadata, submission_id, agency, mandated_report_name, user_guid)
+      # Query for publications with required_report
+      publications = NycGovernmentPublication.where(agency: agency, required_report_name: mandated_report_name)
+                                             .order('date_published_ssi desc')
+      mandated_report = RequiredReport.where(agency_name: agency, name: mandated_report_name).first
+      mandated_report_due_date = RequiredReportDueDate.where(submission_id: submission_id).first
+
+      # Store deleted work's metadata in deleted_publications
+      if metadata.present?
+        metadata[:mandated_report_due_date_id] = mandated_report_due_date.id unless mandated_report_due_date.nil?
+        DeletedPublication.create!(user_guid: user_guid, timestamp: Time.current, metadata: metadata)
+      end
+
+      if mandated_report.present?
+        last_published_date_updated = false
+
+        if publications.present?
+          publications.each do |p|
+            next if p.suppressed? ||
+                    p.late_notice ||
+                    ["Not Required", "Other Publication"].include?(p.required_report_name)
+
+            mandated_report.update(last_published_date: p.date_published)
+            last_published_date_updated = true
+            break
+          end
+        end
+        # Set last_published_date to nil if no previous publication exists
+        mandated_report.update(last_published_date: nil) unless last_published_date_updated
+      end
+
+      # Set submission_id and date_submitted to nil in required_report_due_dates
+      mandated_report_due_date&.update(submission_id: nil, date_submitted: nil)
+
+      # Unsuppress late notice in search results if generated
+      delinquency_id = mandated_report_due_date&.delinquency_report_id
+      Gpp::UpdateLateNoticeSuppressionJob.perform_later(false, delinquency_id) if delinquency_id.present?
+    end
+  end
+end

--- a/app/jobs/gpp/update_due_date_submission_job.rb
+++ b/app/jobs/gpp/update_due_date_submission_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Gpp
+  class UpdateDueDateSubmissionJob < ApplicationJob
+    queue_as :default
+
+    def perform(due_date_id, publication_id)
+      due_date = RequiredReportDueDate.find(due_date_id)
+      return unless due_date
+
+      due_date.update(submission_id: publication_id, date_submitted: Time.current)
+    end
+  end
+end

--- a/app/jobs/gpp/update_late_notice_suppression_job.rb
+++ b/app/jobs/gpp/update_late_notice_suppression_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Gpp
+  class UpdateLateNoticeSuppressionJob < ApplicationJob
+    queue_as :default
+
+    def perform(suppress_late_notice, late_notice_id)
+      late_notice = NycGovernmentPublication.where(id: late_notice_id).first
+      return unless late_notice
+
+      late_notice['suppressed_late_notice'] = suppress_late_notice
+      late_notice.save!
+    end
+  end
+end

--- a/app/jobs/gpp/update_mandated_report_job.rb
+++ b/app/jobs/gpp/update_mandated_report_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Gpp
+  class UpdateMandatedReportJob < ApplicationJob
+    queue_as :default
+
+    def perform(work_id, workflow_action_name)
+      work = NycGovernmentPublication.find(work_id)
+      required_report_name = work.required_report_name
+      date_published = Date.parse(work.date_published)
+      required_report = RequiredReport
+                          .where(agency_name: work.agency, name: required_report_name)
+                          .find_by(end_date: nil) || RequiredReport.where(agency_name: work.agency, name: required_report_name).first
+      due_date = RequiredReportDueDate.find_by(submission_id: work.id)
+
+      case workflow_action_name
+        when 'comment_only'
+          return
+        when 'approve'
+          # Set last_published_date if work is approved and date_published is after the current value of last_published_date
+          if required_report.last_published_date.nil? || (date_published > required_report.last_published_date)
+            required_report.update(last_published_date: date_published)
+          end
+          # Suppress late notice in search results if generated
+          delinquency_id = due_date&.delinquency_report_id
+          Gpp::UpdateLateNoticeSuppressionJob.perform_later(true, delinquency_id) if delinquency_id.present?
+        when 'request_changes'
+          # Set date_submitted to nil on request_changes
+          RequiredReportDueDate.where(submission_id: work.id).first&.update(date_submitted: nil)
+        when 'request_review'
+          # Set date_submitted to the current date and time on request_review
+          RequiredReportDueDate.where(submission_id: work.id).first&.update(date_submitted: Time.current)
+      else
+        return
+      end
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,6 +21,10 @@ class Ability
       can [:agency_required_reports], RequiredReport
     end
 
+    def library_reviewers?
+      current_user&.library_reviewers?
+    end
+
     # Limits creating new objects to a specific group
     #
     # if user_groups.include? 'special_group'

--- a/app/models/gpp/mandated_report_event.rb
+++ b/app/models/gpp/mandated_report_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Gpp
+  class MandatedReportEvent < ApplicationRecord
+    belongs_to :required_report
+    belongs_to :user
+
+    enum event_type: {
+      created: 'created',
+      updated: 'updated',
+      visibility_updated: 'visibility_updated'
+    }
+
+    validates :event_type, presence: true
+  end
+end

--- a/app/models/nyc_government_publication.rb
+++ b/app/models/nyc_government_publication.rb
@@ -73,6 +73,14 @@ class NycGovernmentPublication < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :late_notice, predicate: ::RDF::URI.intern('http://a860-gpp.nyc.gov/late-notice'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :suppressed_late_notice, predicate: ::RDF::URI.intern('http://a860-gpp.nyc.gov/suppressed-late-notice'), multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,7 +2,13 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
-  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
+  include Gpp::LateNoticeFilters
+  self.default_processor_chain += [
+    :add_advanced_parse_q_to_solr,
+    :add_advanced_search_to_solr,
+    :exclude_suppressed_late_notices,
+    :filter_late_notices
+  ]
 
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -73,4 +73,8 @@ class SolrDocument
   def required_report_name
     self[Solrizer.solr_name('required_report_name')]
   end
+
+  def late_notice
+    self[Solrizer.solr_name('late_notice')]
+  end
 end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -1,0 +1,200 @@
+module Hyrax
+  class CollectionPresenter
+    include ModelProxy
+    include PresentsAttributes
+    include ActionView::Helpers::NumberHelper
+    include ActionView::Helpers::TagHelper
+    attr_accessor :solr_document, :current_ability, :request
+    attr_reader :subcollection_count
+    attr_accessor :parent_collections # This is expected to be a Blacklight::Solr::Response with all of the parent collections
+    attr_writer :collection_type
+
+    class_attribute :create_work_presenter_class
+    self.create_work_presenter_class = Hyrax::SelectTypeListPresenter
+
+    # @param [SolrDocument] solr_document
+    # @param [Ability] current_ability
+    # @param [ActionDispatch::Request] request the http request context
+    def initialize(solr_document, current_ability, request = nil)
+      @solr_document = solr_document
+      @current_ability = current_ability
+      @request = request
+      @subcollection_count = 0
+    end
+
+    # CurationConcern methods
+    delegate :stringify_keys, :human_readable_type, :collection?, :representative_id,
+             :to_s, to: :solr_document
+
+    delegate(*Hyrax::CollectionType.collection_type_settings_methods, to: :collection_type, prefix: :collection_type_is)
+
+    def collection_type
+      @collection_type ||= Hyrax::CollectionType.find_by_gid!(collection_type_gid)
+    end
+
+    # Metadata Methods
+    delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language, :embargo_release_date,
+             :lease_expiration_date, :license, :date_created, :resource_type, :based_near, :related_url, :identifier, :thumbnail_path,
+             :title_or_label, :collection_type_gid, :create_date, :modified_date, :visibility, :edit_groups, :edit_people,
+             to: :solr_document
+
+    # Terms is the list of fields displayed by
+    # app/views/collections/_show_descriptions.html.erb
+    def self.terms
+      [:total_items, :size, :resource_type, :creator, :contributor, :keyword, :license, :publisher, :date_created, :subject,
+       :language, :identifier, :based_near, :related_url]
+    end
+
+    def terms_with_values
+      self.class.terms.select { |t| self[t].present? }
+    end
+
+    ##
+    # @param [Symbol] key
+    # @return [Object]
+    def [](key)
+      case key
+      when :size
+        size
+      when :total_items
+        total_items
+      else
+        solr_document.send key
+      end
+    end
+
+    # @deprecated to be removed in 4.0.0; this feature was replaced with a
+    #   hard-coded null implementation
+    # @return [String] 'unknown'
+    def size
+      Deprecation.warn('#size has been deprecated for removal in Hyrax 4.0.0; ' \
+                       'The implementation of the indexed Collection size ' \
+                       'feature is extremely inefficient, so it has been removed. ' \
+                       'This method now returns a hard-coded `"unknown"` for ' \
+                       'compatibility.')
+      'unknown'
+    end
+
+    def total_items
+      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").count
+    end
+
+    # [gpp-override] exclude generated late notices from homepage items count
+    def total_viewable_items
+      if current_ability.admin? || current_ability.library_reviewers?
+        ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").accessible_by(current_ability).count
+      else
+        ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id} AND -late_notice_bsi:true").accessible_by(current_ability).count
+      end
+    end
+
+    def total_viewable_works
+      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id} AND generic_type_sim:Work").accessible_by(current_ability).count
+    end
+
+    def total_viewable_collections
+      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id} AND generic_type_sim:Collection").accessible_by(current_ability).count
+    end
+
+    def collection_type_badge
+      content_tag(:span, collection_type.title, class: "label", style: "background-color: " + collection_type.badge_color + ";")
+    end
+
+    # The total number of parents that this collection belongs to, visible or not.
+    def total_parent_collections
+      parent_collections.nil? ? 0 : parent_collections.response['numFound']
+    end
+
+    # The number of parent collections shown on the current page. This will differ from total_parent_collections
+    # due to pagination.
+    def parent_collection_count
+      parent_collections.nil? ? 0 : parent_collections.documents.size
+    end
+
+    def user_can_nest_collection?
+      current_ability.can?(:deposit, solr_document)
+    end
+
+    def user_can_create_new_nest_collection?
+      current_ability.can?(:create_collection_of_type, collection_type)
+    end
+
+    def show_path
+      Hyrax::Engine.routes.url_helpers.dashboard_collection_path(id, locale: I18n.locale)
+    end
+
+    def banner_file
+      # Find Banner filename
+      ci = CollectionBrandingInfo.where(collection_id: id, role: "banner")
+      "/" + ci[0].local_path.split("/")[-4..-1].join("/") unless ci.empty?
+    end
+
+    def logo_record
+      logo_info = []
+      # Find Logo filename, alttext, linktext
+      cis = CollectionBrandingInfo.where(collection_id: id, role: "logo")
+      return if cis.empty?
+      cis.each do |coll_info|
+        logo_file = File.split(coll_info.local_path).last
+        file_location = "/" + coll_info.local_path.split("/")[-4..-1].join("/") unless logo_file.empty?
+        alttext = coll_info.alt_text
+        linkurl = coll_info.target_url
+        logo_info << { file: logo_file, file_location: file_location, alttext: alttext, linkurl: linkurl }
+      end
+      logo_info
+    end
+
+    # A presenter for selecting a work type to create
+    # this is needed here because the selector is in the header on every page
+    def create_work_presenter
+      @create_work_presenter ||= create_work_presenter_class.new(current_ability.current_user)
+    end
+
+    def create_many_work_types?
+      create_work_presenter.many?
+    end
+
+    def draw_select_work_modal?
+      create_many_work_types?
+    end
+
+    def first_work_type
+      create_work_presenter.first_model
+    end
+
+    def available_parent_collections(scope:)
+      return @available_parents if @available_parents.present?
+      collection = Collection.find(id)
+      colls = Hyrax::Collections::NestedCollectionQueryService.available_parent_collections(child: collection, scope: scope, limit_to_id: nil)
+      @available_parents = colls.map do |col|
+        { "id" => col.id, "title_first" => col.title.first }
+      end
+      @available_parents.to_json
+    end
+
+    def subcollection_count=(total)
+      @subcollection_count = total unless total.nil?
+    end
+
+    # For the Managed Collections tab, determine the label to use for the level of access the user has for this admin set.
+    # Checks from most permissive to most restrictive.
+    # @return String the access label (e.g. Manage, Deposit, View)
+    def managed_access
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.view') if current_ability.can?(:read, solr_document)
+      ''
+    end
+
+    # Determine if the user can perform batch operations on this collection.  Currently, the only
+    # batch operation allowed is deleting, so this is equivalent to checking if the user can delete
+    # the collection determined by criteria...
+    # * user must be able to edit the collection to be able to delete it
+    # * the collection does not have to be empty
+    # @return Boolean true if the user can perform batch actions; otherwise, false
+    def allow_batch?
+      return true if current_ability.can?(:edit, solr_document)
+      false
+    end
+  end
+end

--- a/app/search_builders/gpp/late_notice_filters.rb
+++ b/app/search_builders/gpp/late_notice_filters.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module Gpp
+  module LateNoticeFilters
+
+    # Allow only admins or library staff to see suppressed late notices
+    def exclude_suppressed_late_notices(solr_parameters)
+      return if authorized?
+      solr_parameters[:fq] ||= []
+      solr_parameters[:fq] << '-suppressed_late_notice_bsi:true'
+    end
+
+    # Apply a negative boost to late notices so they appear at the end of search results
+    def filter_late_notices(solr_parameters)
+      solr_parameters[:bq] ||= ''
+      solr_parameters[:bq] += 'late_notice_bsi:true^-10'
+    end
+
+    private
+
+    def authorized?
+      ability = scope.current_ability
+      ability.admin? || ability.current_user&.library_reviewers?
+    end
+  end
+end

--- a/app/search_builders/hyrax/catalog_search_builder.rb
+++ b/app/search_builders/hyrax/catalog_search_builder.rb
@@ -3,11 +3,14 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
+  include Gpp::LateNoticeFilters
   self.default_processor_chain += [
     :add_advanced_parse_q_to_solr,
     :add_advanced_search_to_solr,
     :add_highlighting_to_file_text,
     :show_works_that_contain_files,
+    :exclude_suppressed_late_notices,
+    :filter_late_notices
   ]
 
   def show_works_that_contain_files(solr_parameters)

--- a/app/views/required_reports/_form.html.erb
+++ b/app/views/required_reports/_form.html.erb
@@ -1,100 +1,96 @@
 <%= javascript_include_tag 'required_reports' %>
 
-<%= simple_form_for @required_report, url: mandated_reports_path do |f| %>
-  <% if required_report.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(required_report.errors.count, "error") %> prohibited this mandated_report from being saved:</h2>
+<% error_messages = required_report.errors.full_messages %>
+<div id="alert-error" class="alert alert-danger" role="alert"
+     style="<%= error_messages.any? ? '' : 'display: none;' %>"
+     tabindex="0"
+     data-has-server-errors="<%= error_messages.any? %>">
 
-      <ul>
-        <% required_report.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
+  <% if error_messages.any? %>
+    <h4 class="alert-heading">
+      <%= pluralize(error_messages.count, "error") %> prohibited this mandated report from being saved:
+    </h4>
+    <ul>
+      <% error_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
   <% end %>
+</div>
 
-  <div class="alert alert-danger" id="alert-error" role="alert" style="display: none;" tabindex="0"></div>
+<%= f.input :name,
+            as: :string,
+            input_html: { class: 'form-control', disabled: disabled_fields },
+            required: true
+%>
 
-  <%= f.input :name,
-              as: :string,
-              input_html: { class: 'form-control' },
-              required: true
-  %>
+<%= f.input :agency_name,
+            as: :select,
+            collection: AgenciesService.select_all_options,
+            include_blank: true,
+            input_html: { class: 'form-control', disabled: disabled_fields },
+            required: true
+%>
 
-  <%= f.input :agency_name,
-              as: :select,
-              collection: AgenciesService.select_all_options,
-              include_blank: true,
-              input_html: { class: 'form-control' },
-              required: true
-  %>
+<%= f.input :description,
+            as: :string,
+            input_html: { class: 'form-control' }
+%>
 
-  <%= f.input :description,
-              as: :string,
-              input_html: { class: 'form-control' }
-  %>
+<%= f.input :local_law,
+            as: :string,
+            input_html: { class: 'form-control' }
+%>
 
-  <%= f.input :local_law,
-              as: :string,
-              input_html: { class: 'form-control' }
-  %>
+<%= f.input :charter_and_code,
+            as: :string,
+            input_html: { class: 'form-control' }
+%>
 
-  <%= f.input :charter_and_code,
-              as: :string,
-              input_html: { class: 'form-control' }
-  %>
+<%= f.input :automated_date,
+            as: :select,
+            selected: 'true',
+            input_html: { class: 'form-control', disabled: disabled_fields },
+            required: true
+%>
 
-  <%= f.input :automated_date,
-              as: :select,
-              selected: 'true',
-              input_html: { class: 'form-control' },
-              required: true
-  %>
+<%= f.input :frequency,
+            as: :select,
+            collection: FrequenciesService.select_all_options,
+            input_html: { class: 'form-control', disabled: disabled_fields }
+%>
 
-  <%= f.input :frequency,
-              as: :select,
-              collection: FrequenciesService.select_all_options,
-              input_html: { class: 'form-control' }
-  %>
+<%= f.input :frequency_integer,
+            as: :integer,
+            input_html: { class: 'form-control', min: '0', max: '9999', disabled: disabled_fields }
+%>
 
-  <%= f.input :frequency_integer,
-              as: :integer,
-              input_html: { class: 'form-control', min: '0', max: '9999' }
-  %>
+<%= f.input :other_frequency_description,
+            as: :text,
+            input_html: { class: 'form-control', rows: 3, maxlength: 500, disabled: disabled_fields }
+%>
 
-  <%= f.input :other_frequency_description,
-              as: :text,
-              input_html: { class: 'form-control', rows: 3, maxlength: 500 }
-  %>
+<%= f.input :start_date,
+            as: :string,
+            input_html: { class: 'form-control', multiple: false, placeholder: 'YYYY-MM-DD', disabled: disabled_fields }
+%>
 
-  <%= f.input :start_date,
-              as: :string,
-              input_html: { class: 'form-control', multiple: false, placeholder: 'YYYY-MM-DD' }
-  %>
+<%= f.input :end_date,
+            as: :string,
+            input_html: { class: 'form-control', multiple: false, placeholder: 'YYYY-MM-DD', disabled: disabled_fields }
+%>
 
-  <%= f.input :end_date,
-              as: :string,
-              input_html: { class: 'form-control', multiple: false, placeholder: 'YYYY-MM-DD' }
-  %>
+<%= f.input :required_distribution,
+            as: :string,
+            input_html: { class: 'form-control'}
+%>
 
-  <%= f.input :required_distribution,
-              as: :string,
-              input_html: { class: 'form-control'}
-  %>
+<%= f.input :report_deadline,
+            as: :string,
+            input_html: { class: 'form-control'}
+%>
 
-  <%= f.input :report_deadline,
-              as: :string,
-              input_html: { class: 'form-control'}
-  %>
-
-  <%= f.input :additional_notes,
-              as: :text,
-              input_html: { class: 'form-control', rows: 3, maxlength: 500 }
-  %>
-
-  <div class="actions">
-    <%= f.button :submit,
-                 class: 'btn btn-primary'
-    %>
-  </div>
-<% end %>
+<%= f.input :additional_notes,
+            as: :text,
+            input_html: { class: 'form-control', rows: 3, maxlength: 500 }
+%>

--- a/app/views/required_reports/edit.html.erb
+++ b/app/views/required_reports/edit.html.erb
@@ -1,0 +1,11 @@
+<% provide :page_title, construct_page_title('Edit Mandated Report') %>
+<h1>Edit Mandated Report</h1>
+
+<%= simple_form_for @required_report, url: mandated_report_path(@required_report), method: :patch do |f| %>
+  <%= render 'form', f: f, required_report: @required_report, disabled_fields: true %>
+
+  <div class="actions">
+    <%= link_to 'Cancel', mandated_reports_path(@required_report.id) %> |
+    <%= f.button :submit, 'Update Report', class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/required_reports/new.html.erb
+++ b/app/views/required_reports/new.html.erb
@@ -1,6 +1,11 @@
 <% provide :page_title, construct_page_title('New Mandated Report') %>
 <h1>New Mandated Report</h1>
 
-<%= render 'form', required_report: @required_report %>
+<%= simple_form_for @required_report, url: mandated_reports_path do |f| %>
+  <%= render 'form', required_report: @required_report, disabled_fields: false, f: f %>
 
-<%= link_to 'Back', mandated_reports_path %>
+  <div class="actions">
+    <%= link_to 'Back', mandated_reports_path %> |
+    <%= f.button :submit, class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/required_reports/public_list.html.erb
+++ b/app/views/required_reports/public_list.html.erb
@@ -49,7 +49,7 @@
       <th class="col-md-1">Authorizing Resource (Charter and Code)</th>
       <th class="col-md-1">Last Published Date</th>
       <th class="col-md-1">See All Reports</th>
-      <% if @is_admin %>
+      <% if @can_manage_reports %>
         <th class="col-md-1">Required Distribution</th>
         <th class="col-md-1">Report Deadline</th>
         <th class="col-md-1">Additional Notes</th>
@@ -89,7 +89,7 @@
                       aria: {
                         label: format('Search all, %s for %s', required_report.name, required_report.agency_name)
                       } %></td>
-        <% if @is_admin %>
+        <% if @can_manage_reports %>
           <td><%= required_report.required_distribution %></td>
           <td><%= required_report.report_deadline %></td>
           <td><%= required_report.additional_notes %></td>

--- a/app/views/required_reports/show.html.erb
+++ b/app/views/required_reports/show.html.erb
@@ -1,6 +1,4 @@
-<% provide :page_title, construct_page_title('Show Mandated Reports') %>
-
-<p id="notice"><%= notice %></p>
+<% provide :page_title, construct_page_title('Show Mandated Report') %>
 
 <p>
   <strong>Agency:</strong>
@@ -77,5 +75,5 @@
   <%= @required_report.additional_notes %>
 </p>
 
-<!--<%#= link_to 'Edit', edit_mandated_report_path(@required_report) %> |-->
-<%= link_to 'Back', mandated_reports_path %>
+<%= link_to 'Back', mandated_reports_path %> |
+<%= link_to 'Edit', edit_mandated_report_path(@required_report), class: 'btn btn-primary' %>

--- a/app/workers/report_request_worker.rb
+++ b/app/workers/report_request_worker.rb
@@ -6,6 +6,7 @@ class ReportRequestWorker
     calendar = Rails.configuration.calendar
     today = Date.today
     user = User.find_by(email: ENV['LIBRARY_USER_EMAIL'])
+    ability = ::Ability.new(user)
 
     # Do not proceed if today is not a business day
     return unless calendar.business_day?(today)
@@ -51,17 +52,19 @@ class ReportRequestWorker
                      date_published: today.to_s,
                      calendar_year: [today.year.to_s],
                      language: ['English'],
+                     late_notice: true,
+                     suppressed_late_notice: false,
                      member_of_collections_attributes: { '0' => {
                        id: Collection.where(title: 'Government Publication').first.id,
                        _destroy: 'false'
                      } } }
-      actor_environment = Hyrax::Actors::Environment.new(work, user.ability, attributes)
+      actor_environment = Hyrax::Actors::Environment.new(work, ability, attributes)
       status = actor.create(actor_environment)
 
       if status
         approve_attributes = { name: 'approve', comment: '' }
         workflow_action_form = Hyrax::Forms::WorkflowActionForm.new(
-          current_ability: user.ability,
+          current_ability: ability,
           work: work,
           attributes: approve_attributes
         )

--- a/db/migrate/20250707193406_create_mandated_report_events.rb
+++ b/db/migrate/20250707193406_create_mandated_report_events.rb
@@ -1,0 +1,13 @@
+class CreateMandatedReportEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :mandated_report_events do |t|
+      t.references :required_report, foreign_key: true
+      t.references :user, foreign_key: true
+      t.string :event_type, null: false
+      t.jsonb :previous_value
+      t.jsonb :new_value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_05_143718) do
+ActiveRecord::Schema.define(version: 2025_07_07_193406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -340,6 +340,18 @@ ActiveRecord::Schema.define(version: 2025_06_05_143718) do
     t.string "message_id"
     t.index ["notification_id"], name: "index_mailboxer_receipts_on_notification_id"
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
+  end
+
+  create_table "mandated_report_events", force: :cascade do |t|
+    t.bigint "required_report_id"
+    t.bigint "user_id"
+    t.string "event_type", null: false
+    t.jsonb "previous_value"
+    t.jsonb "new_value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["required_report_id"], name: "index_mandated_report_events_on_required_report_id"
+    t.index ["user_id"], name: "index_mandated_report_events_on_user_id"
   end
 
   create_table "minter_states", id: :serial, force: :cascade do |t|
@@ -750,6 +762,8 @@ ActiveRecord::Schema.define(version: 2025_06_05_143718) do
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "mandated_report_events", "required_reports"
+  add_foreign_key "mandated_report_events", "users"
   add_foreign_key "permission_template_accesses", "permission_templates"
   add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
   add_foreign_key "required_report_due_dates", "required_reports"


### PR DESCRIPTION
This PR includes the following updates:
- Editable Mandated Report Fields: Admins and Library Reviewers can now edit the text fields on Mandated Report forms.
- Mandated Report Logging: Activity is now logged when a Mandated Report is created or updated.
- Late Notice Enhancements: Late notices can now be suppressed, and filtering support has been added.

Deployment Notes:
- Run RAILS_ENV=production bundle exec rake assets:precompile
- Run RAILS_ENV=production bundle exec rake db:migrate
- A data migration or script must be run to update existing records with the new late notice properties (late_notice, suppressed_late_notice).